### PR TITLE
fix: add Rich progress indicators to reki scan and reki note import

### DIFF
--- a/src/rekipedia/cli/note.py
+++ b/src/rekipedia/cli/note.py
@@ -9,6 +9,7 @@ import tempfile
 from pathlib import Path
 
 import click
+from rich.progress import BarColumn, Progress, SpinnerColumn, TaskProgressColumn, TextColumn
 
 from rekipedia.storage.sqlite_store import SqliteStore
 
@@ -146,8 +147,18 @@ def note_import(ctx: click.Context, file: str, dry_run: bool) -> None:
                 click.echo(f"  [{n.get('tags','')}] {n['content'][:60]}")
             return
 
-        for n in new_notes:
-            store.upsert_note(content=n["content"], tags=n.get("tags", ""), source="import")
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            BarColumn(),
+            TaskProgressColumn(),
+            transient=True,
+        ) as progress:
+            task = progress.add_task(f"Importing notes…", total=len(new_notes))
+            for n in new_notes:
+                store.upsert_note(content=n["content"], tags=n.get("tags", ""), source="import")
+                progress.advance(task)
+
         click.echo(f"Imported {len(new_notes)} note(s) (skipped {skipped} duplicates).")
     finally:
         store.close()

--- a/src/rekipedia/cli/scan.py
+++ b/src/rekipedia/cli/scan.py
@@ -7,6 +7,7 @@ from pathlib import Path
 import click
 import yaml
 from rich.console import Console
+from rich.progress import Progress, SpinnerColumn, TextColumn, TimeElapsedColumn
 
 from rekipedia.models.contracts import LLMConfig
 
@@ -150,31 +151,56 @@ def scan_cmd(
     from rekipedia.orchestrator.run_digest import run_digest  # noqa: PLC0415
 
     # In verbose mode: print each log line directly so tqdm + log interleave cleanly
-    # In normal mode: suppress the text progress callback (tqdm bars handle display)
-    def _log(msg: str) -> None:
-        if verbose:
+    # In normal mode: update a Rich spinner so the user sees live phase labels
+    if verbose:
+        def _log(msg: str) -> None:
             console.print(f"  [dim]{msg}[/dim]")
 
-    try:
-        run_digest(
-            repo_root=repo,
-            output_dir=output_dir,
-            llm_config=llm_config,
-            force_local=no_docker,
-            verbose=verbose,
-            progress=_log,
-            languages=lang_list,
-            no_llm=no_llm,
-            stdout_refactor=stdout_refactor,
-        )
-    except Exception as exc:
-        if verbose:
-            import traceback
+        try:
+            run_digest(
+                repo_root=repo,
+                output_dir=output_dir,
+                llm_config=llm_config,
+                force_local=no_docker,
+                verbose=verbose,
+                progress=_log,
+                languages=lang_list,
+                no_llm=no_llm,
+                stdout_refactor=stdout_refactor,
+            )
+        except Exception as exc:
             console.print_exception(show_locals=True)
-        else:
-            console.print(f"[bold red]Error:[/bold red] {exc}")
-            console.print("[dim]Tip: run with --verbose for full debug output[/dim]")
-        sys.exit(1)
+            sys.exit(1)
+    else:
+        with Progress(
+            SpinnerColumn(),
+            TextColumn("[progress.description]{task.description}"),
+            TimeElapsedColumn(),
+            console=console,
+            transient=False,
+        ) as progress:
+            task = progress.add_task("Scanning…", total=None)
+
+            def _log(msg: str) -> None:
+                progress.update(task, description=msg)
+
+            try:
+                run_digest(
+                    repo_root=repo,
+                    output_dir=output_dir,
+                    llm_config=llm_config,
+                    force_local=no_docker,
+                    verbose=verbose,
+                    progress=_log,
+                    languages=lang_list,
+                    no_llm=no_llm,
+                    stdout_refactor=stdout_refactor,
+                )
+            except Exception as exc:
+                progress.stop()
+                console.print(f"[bold red]Error:[/bold red] {exc}")
+                console.print("[dim]Tip: run with --verbose for full debug output[/dim]")
+                sys.exit(1)
 
     console.rule()
     console.print("[bold green]✓ Scan complete[/bold green]")


### PR DESCRIPTION
## Summary

Fixes #98 and #99 — adds live progress feedback to two CLI commands that previously had none.

## Changes

### `reki scan` (#98)
- Normal mode now wraps `run_digest` in a `rich.progress.Progress` spinner showing phase labels (e.g. `Extracting symbols…`, `Building wiki pages…`) + elapsed time
- Matches the existing pattern in `reki update` (`cli/update.py`)
- Verbose mode (`--verbose`) unchanged — still prints raw log lines

### `reki note import` (#99)
- Replaced the silent `for` loop with a Rich `Progress` bar: spinner + bar + `N/M` counter
- User sees real-time progress during bulk imports
- `--dry-run` path unchanged (no bar needed)

## Before / After

| Command | Before | After |
|---------|--------|-------|
| `reki scan .` | Silent (only internal tqdm shard bars) | Spinner + phase label + elapsed time |
| `reki note import file.yaml` | Silent until done | `⠋ Importing notes… ━━━━ 3/10` |
