### PR TITLE
fix: algorithm improvements — BM25 IDF, impact edges, parallel tool calls, configurable gap threshold

### DIFF
--- a/src/rekipedia/analysis/cross_repo_search.py
+++ b/src/rekipedia/analysis/cross_repo_search.py
@@ -1,6 +1,8 @@
 """Cross-repo search — fan-out across multiple SQLite stores."""
 from __future__ import annotations
+import math
 import re
+from collections import Counter
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
@@ -15,8 +17,34 @@ def _tokenize_symbol(name: str) -> list[str]:
     return result or [name.lower()]
 
 
-def _score_bm25(query_tokens: list[str], symbol_tokens: list[str]) -> float:
-    """Simple BM25-inspired scoring without external deps."""
+def _compute_idf(all_symbols: list) -> dict[str, float]:
+    """Compute BM25 IDF for each token across the full symbol corpus.
+
+    IDF(t) = log((N - df(t) + 0.5) / (df(t) + 0.5) + 1)
+
+    where N = total symbol count, df(t) = number of symbols containing token t.
+    Returns a dict mapping token → idf score.
+    """
+    N = len(all_symbols)
+    if N == 0:
+        return {}
+    df: Counter[str] = Counter()
+    for s in all_symbols:
+        name = s.name if hasattr(s, 'name') else s.get('name', '')
+        tokens = set(_tokenize_symbol(name))
+        df.update(tokens)
+    return {
+        token: math.log((N - freq + 0.5) / (freq + 0.5) + 1)
+        for token, freq in df.items()
+    }
+
+
+def _score_bm25(
+    query_tokens: list[str],
+    symbol_tokens: list[str],
+    idf: dict[str, float],
+) -> float:
+    """BM25 scoring with per-corpus IDF weights."""
     k1, b, avgdl = 1.5, 0.75, 5.0
     dl = len(symbol_tokens)
     score = 0.0
@@ -27,8 +55,8 @@ def _score_bm25(query_tokens: list[str], symbol_tokens: list[str]) -> float:
         tf = tf_map.get(qt, 0)
         if tf == 0:
             continue
-        idf = 1.0  # simplified
-        score += idf * (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * dl / avgdl))
+        token_idf = idf.get(qt, 1.0)  # fallback to 1.0 for unseen tokens
+        score += token_idf * (tf * (k1 + 1)) / (tf + k1 * (1 - b + b * dl / avgdl))
     return score
 
 
@@ -42,6 +70,10 @@ def _search_single_repo(db_path: Path, query: str, kind: str | None = None) -> l
             return []
         symbols = store.get_all_symbols(run_id)
         query_tokens = _tokenize_symbol(query)
+
+        # Compute per-corpus IDF — rare tokens get higher weight
+        idf = _compute_idf(symbols)
+
         results = []
         for s in symbols:
             name = s.name if hasattr(s, 'name') else s.get('name', '')
@@ -51,7 +83,7 @@ def _search_single_repo(db_path: Path, query: str, kind: str | None = None) -> l
             if kind and sym_kind != kind:
                 continue
             symbol_tokens = _tokenize_symbol(name)
-            score = _score_bm25(query_tokens, symbol_tokens)
+            score = _score_bm25(query_tokens, symbol_tokens, idf)
             if score > 0:
                 results.append({'name': name, 'file': file, 'kind': sym_kind, 'score': score, 'repo': str(db_path.parent.parent)})
         results.sort(key=lambda x: x['score'], reverse=True)
@@ -65,21 +97,21 @@ def search_all_repos(query: str, repo_dirs: list[str] | None = None, kind: str |
     if repo_dirs is None:
         from rekipedia.watcher.watcher import list_repos
         repo_dirs = list_repos()
-    
+
     db_paths = []
     for repo in repo_dirs:
         db = Path(repo) / '.rekipedia' / 'rekipedia.db'
         if db.exists():
             db_paths.append(db)
-    
+
     if not db_paths:
         return []
-    
+
     all_results = []
     with ThreadPoolExecutor(max_workers=min(len(db_paths), 8)) as pool:
         futures = {pool.submit(_search_single_repo, db, query, kind): db for db in db_paths}
         for fut in as_completed(futures):
             all_results.extend(fut.result())
-    
+
     all_results.sort(key=lambda x: x['score'], reverse=True)
     return all_results[:200]

--- a/src/rekipedia/analysis/graph_analysis.py
+++ b/src/rekipedia/analysis/graph_analysis.py
@@ -1,8 +1,14 @@
 """Graph analysis utilities for rekipedia."""
 from __future__ import annotations
 
+import math
+import os
 from collections import defaultdict
 from typing import TYPE_CHECKING
+
+# Minimum call count for a symbol to be flagged as a knowledge gap.
+# Override with REKIPEDIA_GAP_MIN_CALLS env var.
+_GAP_MIN_CALLS = int(os.environ.get("REKIPEDIA_GAP_MIN_CALLS", "3"))
 
 if TYPE_CHECKING:
     from rekipedia.models.contracts import Relationship
@@ -80,7 +86,7 @@ def _build_knowledge_gaps(combined: "AnalysisResult") -> list[dict]:
     gaps = []
     valid_kinds = {"function", "method", "class"}
     for name, count in call_count.items():
-        if count < 3:
+        if count < _GAP_MIN_CALLS:
             continue
         if name in test_covered:
             continue

--- a/src/rekipedia/analysis/impact.py
+++ b/src/rekipedia/analysis/impact.py
@@ -2,6 +2,10 @@
 from __future__ import annotations
 from collections import deque
 
+# Relationship kinds that represent a dependency — changing the target
+# may affect the source. Extend this set to widen the blast radius.
+_IMPACT_EDGE_KINDS: frozenset[str] = frozenset({"calls", "imports", "inherits", "uses"})
+
 
 def compute_impact(
     target_file: str,
@@ -27,7 +31,7 @@ def compute_impact(
         frm = rel.from_ if hasattr(rel, "from_") else rel.get("from_", "") or rel.get("from", "")
         to = rel.to if hasattr(rel, "to") else rel.get("to", "")
         kind = rel.kind if hasattr(rel, "kind") else rel.get("kind", "")
-        if kind == "calls" and frm and to:
+        if kind in _IMPACT_EDGE_KINDS and frm and to:
             reverse.setdefault(to, []).append(frm)
 
     # Seed: all symbols in target_file

--- a/src/rekipedia/orchestrator/agent_ask.py
+++ b/src/rekipedia/orchestrator/agent_ask.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import json
 import logging
 import os
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from pathlib import Path
 
 import litellm
@@ -330,25 +331,44 @@ class AgentAsk:
                     "tool_calls": [tc.model_dump() for tc in tool_calls],
                 })
 
-            # Dispatch each tool call
-            for tc in tool_calls:
+            # Dispatch tool calls in parallel — calls within one turn are independent
+            finish_answer: str | None = None
+            tool_results: list[tuple[str, str]] = []  # (tool_call_id, result)
+
+            def _dispatch_one(tc) -> tuple[str, str, bool, str]:
+                """Returns (tc_id, result, is_finish, answer)."""
                 fn_name = tc.function.name
                 try:
                     fn_args = json.loads(tc.function.arguments)
                 except json.JSONDecodeError:
                     fn_args = {}
-
                 if fn_name == "finish":
-                    return fn_args.get("answer", "")
-
+                    return tc.id, "", True, fn_args.get("answer", "")
                 result = self._handler.dispatch(fn_name, fn_args)
                 logger.debug("Tool %s(%s) → %d chars", fn_name, fn_args, len(result))
+                return tc.id, result, False, ""
 
-                messages.append({
-                    "role": "tool",
-                    "tool_call_id": tc.id,
-                    "content": result,
-                })
+            with ThreadPoolExecutor(max_workers=min(len(tool_calls), 4)) as pool:
+                futures = {pool.submit(_dispatch_one, tc): tc for tc in tool_calls}
+                for fut in as_completed(futures):
+                    tc_id, result, is_finish, answer = fut.result()
+                    if is_finish:
+                        finish_answer = answer
+                    else:
+                        tool_results.append((tc_id, result))
+
+            if finish_answer is not None:
+                return finish_answer
+
+            # Append tool results in original tool_call order for deterministic context
+            id_to_result = dict(tool_results)
+            for tc in tool_calls:
+                if tc.id in id_to_result:
+                    messages.append({
+                        "role": "tool",
+                        "tool_call_id": tc.id,
+                        "content": id_to_result[tc.id],
+                    })
 
         # Max iterations reached — ask for final answer without tools
         messages.append({


### PR DESCRIPTION
## Summary

Fixes 4 issues found during algorithm review of rekipedia's core analysis engine.

### Changes

| Issue | File | Fix |
|---|---|---|
| #102 | `analysis/cross_repo_search.py` | BM25 now uses per-corpus IDF (Robertson-Spärck Jones formula) instead of hardcoded `1.0` |
| #103 | `analysis/graph_analysis.py` | Knowledge gap threshold reads from `REKIPEDIA_GAP_MIN_CALLS` env var (default: 3) |
| #104 | `analysis/impact.py` | Impact BFS now traverses `calls`, `imports`, `inherits`, `uses` edges |
| #105 | `orchestrator/agent_ask.py` | Tool calls within one LLM turn now dispatched in parallel via `ThreadPoolExecutor` |

### Details

**#102 — BM25 IDF:**
Common tokens like `get`, `set`, `init` were weighted equally to specific tokens like `ShardPlanner`. Now uses `IDF(t) = log((N - df(t) + 0.5) / (df(t) + 0.5) + 1)` computed from the full symbol corpus.

**#103 — Gap min_calls:**
Replaces `if count < 3` with `if count < _GAP_MIN_CALLS` where `_GAP_MIN_CALLS = int(os.environ.get("REKIPEDIA_GAP_MIN_CALLS", "3"))`.

**#104 — Impact edges:**
Adds `_IMPACT_EDGE_KINDS = frozenset({"calls", "imports", "inherits", "uses"})` — base class changes and import-level dependencies now correctly surface affected files.

**#105 — Parallel tool calls:**
Independent tool calls within a single LLM turn run concurrently. Results are re-ordered to match original `tool_call` order before appending to the message history (deterministic context).
