### PR TITLE
fix: make _score_bm25 idf param optional — restore backward compat for tests

### DIFF
--- a/src/rekipedia/analysis/cross_repo_search.py
+++ b/src/rekipedia/analysis/cross_repo_search.py
@@ -42,9 +42,18 @@ def _compute_idf(all_symbols: list) -> dict[str, float]:
 def _score_bm25(
     query_tokens: list[str],
     symbol_tokens: list[str],
-    idf: dict[str, float],
+    idf: dict[str, float] | None = None,
 ) -> float:
-    """BM25 scoring with per-corpus IDF weights."""
+    """BM25 scoring with per-corpus IDF weights.
+
+    Args:
+        query_tokens: Tokenised query.
+        symbol_tokens: Tokenised symbol name.
+        idf: Per-corpus IDF map from _compute_idf(). If None, falls back to
+             idf=1.0 for all tokens (original simplified behaviour).
+    """
+    if idf is None:
+        idf = {}
     k1, b, avgdl = 1.5, 0.75, 5.0
     dl = len(symbol_tokens)
     score = 0.0


### PR DESCRIPTION
## Problem
PR #106 changed `_score_bm25(query_tokens, symbol_tokens)` signature to require a third `idf` argument, breaking 3 existing tests that call the function directly without an `idf` map:

```
FAILED tests/test_cross_repo_search.py::test_bm25_score_nonzero_partial_match
FAILED tests/test_cross_repo_search.py::test_bm25_zero_for_no_match
FAILED tests/test_cross_repo_search.py::test_entry_point_query_finds_main_entrypoint
TypeError: _score_bm25() missing 1 required positional argument: 'idf'
```

## Fix
Make `idf` optional with default `None` (equivalent to empty dict → falls back to `idf=1.0` per token):

```python
def _score_bm25(query_tokens, symbol_tokens, idf=None):
    if idf is None:
        idf = {}
```

Internal calls from `_search_single_repo` still pass the computed IDF dict — no change in production behaviour.
