### PR TITLE
feat(#95): Go AST-aware chunking — symbol-boundary RAG for .go files

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,37 @@
 # Release Notes
 
+## v0.8.1 — Go AST-Aware Chunking (Issue #95)
+
+### What's new
+
+#### Symbol-boundary chunking for `.go` files
+- `chunkGo()` in `go/internal/rag/chunker.go` replaces the naive sliding-window for all `.go` files
+- Detects `func` / `type` / `var` / `const` top-level declaration boundaries via regex (no CGO, no tree-sitter dep)
+- Merges segments < 200 runes forward to avoid micro-chunks
+- Oversized segments (> 2000 runes) fall back to `chunkWindow` for sub-splitting
+- Line numbers preserved accurately through boundary offset math
+- `chunkWindow()` extracted as a named, reusable function (used by Python / TS / all other code)
+- 8 new Go unit tests — all 19 `rag` package tests pass ✅
+
+### Why it matters
+Go RAG quality was significantly below Python baseline (naive 2000-rune fixed window often split functions mid-body). Go files now get the same semantic chunking Python has had from day one.
+
+---
+
+## v0.8.0 — Agentic ReAct Ask Loop (Issue #94)
+
+### What's new
+
+#### `reki ask --agentic` / `close-wiki ask --agentic`
+- ReAct tool-calling loop — LLM iterates up to 5 times, calling tools before delivering a final answer
+- Tools exposed: `search_code`, `get_symbol`, `get_page`, `get_relationships`
+- `LLMClient.call_with_tools()` for multi-turn function-calling (Python + Go)
+- `SqliteStore.search_symbols()` + `GetRelationshipsBySymbol()` (Go)
+- `REKIPEDIA_AGENTIC=1` env var as alternative to `--agentic` flag
+- 10 new unit tests (all passing ✅)
+
+---
+
 ## v0.7.3 — is_implementation Heuristic in Planner & Token-Aware File Skip
 
 ### What's new

--- a/go/cmd/close-wiki/cmd/root.go
+++ b/go/cmd/close-wiki/cmd/root.go
@@ -11,7 +11,7 @@ import (
 
 // Version is injected at build time via -ldflags.
 var (
-	version = "dev"
+	version = "0.8.1"
 	commit  = "none"
 	date    = "unknown"
 )

--- a/go/internal/rag/chunker.go
+++ b/go/internal/rag/chunker.go
@@ -4,6 +4,7 @@ package rag
 import (
 	"fmt"
 	"path/filepath"
+	"regexp"
 	"strings"
 )
 
@@ -33,9 +34,19 @@ const (
 	chunkOverlap = 200
 	maxCodeSize  = 320000
 	maxDocSize   = 32000
+	minChunkRune = 200 // merge chunks smaller than this with the next one
 )
 
+// reGoTopLevel matches the first line of a top-level Go declaration.
+// Groups: (1) keyword — func/type/var/const
+var reGoTopLevel = regexp.MustCompile(`^(?:func|type|var|const)\s`)
+
+// reGoComment matches a full-line comment.
+var reGoComment = regexp.MustCompile(`^//`)
+
 // ChunkFile splits a file's content into overlapping chunks.
+// For .go files it uses symbol-boundary chunking (func/type/var/const boundaries).
+// For other code/doc files it falls back to the line-boundary sliding-window strategy.
 // Returns nil if the file should be skipped.
 func ChunkFile(path, content string) []Chunk {
 	ext := strings.ToLower(filepath.Ext(path))
@@ -54,11 +65,130 @@ func ChunkFile(path, content string) []Chunk {
 		return nil
 	}
 
-	lines := strings.Split(content, "\n")
+	if ext == ".go" {
+		return chunkGo(path, content)
+	}
+	return chunkWindow(path, content)
+}
 
+// ---------------------------------------------------------------------------
+// Go AST-aware chunker
+// ---------------------------------------------------------------------------
+
+// chunkGo splits a .go file at top-level declaration boundaries.
+// Strategy (mirrors Python _symbol_chunk_file):
+//  1. Identify "boundary lines" — lines that start a top-level declaration.
+//  2. Group lines between boundaries into segments.
+//  3. Merge segments that are too small (< minChunkRune runes) with the next.
+//  4. If a segment exceeds chunkSize, further split it with chunkWindow.
+func chunkGo(path, content string) []Chunk {
+	lines := strings.Split(content, "\n")
+	// Collect boundary line indices (0-based).
+	boundaries := []int{0}
+	for i, line := range lines {
+		if i == 0 {
+			continue
+		}
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		// A top-level declaration starts at column 0 (no leading whitespace)
+		// and matches func/type/var/const.
+		if line[0] != ' ' && line[0] != '\t' && line[0] != '/' &&
+			(reGoTopLevel.MatchString(line) || reGoComment.MatchString(strings.TrimSpace(line))) {
+			// Only add boundary on func/type/var/const, not plain comments
+			if reGoTopLevel.MatchString(line) {
+				boundaries = append(boundaries, i)
+			}
+		}
+	}
+	boundaries = append(boundaries, len(lines))
+
+	// Build raw segments between boundaries.
+	type segment struct {
+		startLine int // 1-based
+		endLine   int // 1-based inclusive
+		text      string
+	}
+	var segments []segment
+	for i := 0; i < len(boundaries)-1; i++ {
+		start := boundaries[i]
+		end := boundaries[i+1]
+		segLines := lines[start:end]
+		text := strings.Join(segLines, "\n")
+		segments = append(segments, segment{
+			startLine: start + 1,
+			endLine:   end, // end is exclusive boundary, so last line = end-1+1 = end
+			text:      text,
+		})
+	}
+
+	// Merge small segments forward.
+	merged := make([]segment, 0, len(segments))
+	for _, seg := range segments {
+		if len(merged) > 0 && len([]rune(merged[len(merged)-1].text)) < minChunkRune {
+			prev := merged[len(merged)-1]
+			merged[len(merged)-1] = segment{
+				startLine: prev.startLine,
+				endLine:   seg.endLine,
+				text:      prev.text + "\n" + seg.text,
+			}
+		} else {
+			merged = append(merged, seg)
+		}
+	}
+
+	// Emit chunks — split oversized segments with chunkWindow.
 	var chunks []Chunk
+	chunkIdx := 0
+	for _, seg := range merged {
+		runes := []rune(seg.text)
+		if len(runes) <= chunkSize {
+			if strings.TrimSpace(seg.text) == "" {
+				continue
+			}
+			chunks = append(chunks, Chunk{
+				ID:        fmt.Sprintf("%s#%d", path, chunkIdx),
+				FilePath:  path,
+				StartLine: fmt.Sprintf("%d", seg.startLine),
+				EndLine:   fmt.Sprintf("%d", seg.endLine),
+				Text:      seg.text,
+			})
+			chunkIdx++
+		} else {
+			// Oversized: window-chunk the segment, preserving line offsets.
+			sub := chunkWindow(path, seg.text)
+			for _, sc := range sub {
+				// Adjust line numbers by segment offset.
+				startOff := seg.startLine - 1
+				sl := parseLineNum(sc.StartLine) + startOff
+				el := parseLineNum(sc.EndLine) + startOff
+				chunks = append(chunks, Chunk{
+					ID:        fmt.Sprintf("%s#%d", path, chunkIdx),
+					FilePath:  path,
+					StartLine: fmt.Sprintf("%d", sl),
+					EndLine:   fmt.Sprintf("%d", el),
+					Text:      sc.Text,
+				})
+				chunkIdx++
+			}
+		}
+	}
+	return chunks
+}
+
+// ---------------------------------------------------------------------------
+// Line-boundary sliding window (used for non-Go code + docs)
+// ---------------------------------------------------------------------------
+
+// chunkWindow chunks content using a sliding window that never splits mid-line.
+func chunkWindow(path, content string) []Chunk {
+	lines := strings.Split(content, "\n")
 	runes := []rune(content)
 	total := len(runes)
+
+	var chunks []Chunk
 	idx := 0
 	chunkIdx := 0
 
@@ -67,9 +197,21 @@ func ChunkFile(path, content string) []Chunk {
 		if end > total {
 			end = total
 		}
-		text := string(runes[idx:end])
 
-		// Compute start/end line numbers
+		// Snap end to nearest newline (don't split mid-line)
+		if end < total {
+			for end > idx && runes[end] != '\n' {
+				end--
+			}
+			if end == idx {
+				end = idx + chunkSize // no newline found, accept mid-line split
+				if end > total {
+					end = total
+				}
+			}
+		}
+
+		text := string(runes[idx:end])
 		startLine := countLines(string(runes[:idx]), lines)
 		endLine := startLine + strings.Count(text, "\n")
 
@@ -87,10 +229,19 @@ func ChunkFile(path, content string) []Chunk {
 		}
 		idx += chunkSize - chunkOverlap
 	}
-
 	return chunks
 }
 
 func countLines(before string, _ []string) int {
 	return strings.Count(before, "\n")
+}
+
+func parseLineNum(s string) int {
+	n := 0
+	for _, c := range s {
+		if c >= '0' && c <= '9' {
+			n = n*10 + int(c-'0')
+		}
+	}
+	return n
 }

--- a/go/internal/rag/chunker.go
+++ b/go/internal/rag/chunker.go
@@ -95,12 +95,8 @@ func chunkGo(path, content string) []Chunk {
 		}
 		// A top-level declaration starts at column 0 (no leading whitespace)
 		// and matches func/type/var/const.
-		if line[0] != ' ' && line[0] != '\t' && line[0] != '/' &&
-			(reGoTopLevel.MatchString(line) || reGoComment.MatchString(strings.TrimSpace(line))) {
-			// Only add boundary on func/type/var/const, not plain comments
-			if reGoTopLevel.MatchString(line) {
-				boundaries = append(boundaries, i)
-			}
+		if reGoTopLevel.MatchString(line) {
+			boundaries = append(boundaries, i)
 		}
 	}
 	boundaries = append(boundaries, len(lines))

--- a/go/internal/rag/chunker_test.go
+++ b/go/internal/rag/chunker_test.go
@@ -1,0 +1,232 @@
+package rag
+
+import (
+	"strings"
+	"testing"
+)
+
+// ---------------------------------------------------------------------------
+// Helper
+// ---------------------------------------------------------------------------
+
+func totalText(chunks []Chunk) string {
+	parts := make([]string, len(chunks))
+	for i, c := range chunks {
+		parts[i] = c.Text
+	}
+	return strings.Join(parts, "")
+}
+
+// ---------------------------------------------------------------------------
+// chunkGo — symbol-boundary chunking
+// ---------------------------------------------------------------------------
+
+func TestChunkGo_SingleFunc(t *testing.T) {
+	src := `package main
+
+func Hello() string {
+	return "hello"
+}
+`
+	chunks := ChunkFile("foo.go", src)
+	if len(chunks) == 0 {
+		t.Fatal("expected at least one chunk")
+	}
+	// The function body must appear in some chunk.
+	found := false
+	for _, c := range chunks {
+		if strings.Contains(c.Text, "Hello") {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("function Hello not found in any chunk")
+	}
+}
+
+func TestChunkGo_MultipleFuncs_SeparateChunks(t *testing.T) {
+	// Build a source with two large-enough functions that they shouldn't be merged.
+	var sb strings.Builder
+	sb.WriteString("package main\n\nimport \"fmt\"\n\n")
+	// First function — large enough to avoid merging (> minChunkRune runes)
+	sb.WriteString("func Alpha() {\n")
+	for i := 0; i < 20; i++ {
+		sb.WriteString("\tfmt.Println(\"alpha line\")\n")
+	}
+	sb.WriteString("}\n\n")
+	// Second function
+	sb.WriteString("func Beta() {\n")
+	for i := 0; i < 20; i++ {
+		sb.WriteString("\tfmt.Println(\"beta line\")\n")
+	}
+	sb.WriteString("}\n")
+
+	src := sb.String()
+	chunks := ChunkFile("two.go", src)
+
+	hasAlpha, hasBeta := false, false
+	for _, c := range chunks {
+		if strings.Contains(c.Text, "func Alpha") {
+			hasAlpha = true
+		}
+		if strings.Contains(c.Text, "func Beta") {
+			hasBeta = true
+		}
+	}
+	if !hasAlpha {
+		t.Error("func Alpha not found in any chunk")
+	}
+	if !hasBeta {
+		t.Error("func Beta not found in any chunk")
+	}
+}
+
+func TestChunkGo_TypeDeclaration(t *testing.T) {
+	src := `package models
+
+type Config struct {
+	Host string
+	Port int
+}
+
+type Handler func(w http.ResponseWriter, r *http.Request)
+`
+	chunks := ChunkFile("models.go", src)
+	hasConfig, hasHandler := false, false
+	for _, c := range chunks {
+		if strings.Contains(c.Text, "Config") {
+			hasConfig = true
+		}
+		if strings.Contains(c.Text, "Handler") {
+			hasHandler = true
+		}
+	}
+	if !hasConfig {
+		t.Error("type Config not found in chunks")
+	}
+	if !hasHandler {
+		t.Error("type Handler not found in chunks")
+	}
+}
+
+func TestChunkGo_SmallFuncsMerged(t *testing.T) {
+	// Two tiny one-liner funcs: each alone is < minChunkRune runes, so
+	// they should be merged into one chunk (or at most two chunks, never
+	// resulting in empty single-function micro-chunks).
+	src := `package util
+
+func Inc(n int) int { return n + 1 }
+
+func Dec(n int) int { return n - 1 }
+`
+	chunks := ChunkFile("util.go", src)
+	// Both symbols must be present
+	combined := totalText(chunks)
+	if !strings.Contains(combined, "Inc") {
+		t.Error("Inc missing from chunks")
+	}
+	if !strings.Contains(combined, "Dec") {
+		t.Error("Dec missing from chunks")
+	}
+}
+
+func TestChunkGo_OversizedFuncSplit(t *testing.T) {
+	// A single function that is > chunkSize runes must be split into multiple chunks.
+	var sb strings.Builder
+	sb.WriteString("package main\n\nfunc BigFunc() {\n")
+	for i := 0; i < 200; i++ {
+		sb.WriteString("\t// this is a very long line to pad the function body with content\n")
+	}
+	sb.WriteString("}\n")
+	src := sb.String()
+
+	chunks := ChunkFile("big.go", src)
+	if len(chunks) < 2 {
+		t.Errorf("expected oversized func to produce ≥2 chunks, got %d", len(chunks))
+	}
+}
+
+func TestChunkGo_LineNumbersMonotonic(t *testing.T) {
+	var sb strings.Builder
+	sb.WriteString("package main\n\n")
+	for i := 0; i < 5; i++ {
+		sb.WriteString("func F() {\n\treturn\n}\n\n")
+	}
+	src := sb.String()
+	chunks := ChunkFile("lines.go", src)
+
+	prev := 0
+	for _, c := range chunks {
+		sl := parseLineNum(c.StartLine)
+		if sl < prev {
+			t.Errorf("non-monotonic start line: %d after %d", sl, prev)
+		}
+		prev = sl
+	}
+}
+
+func TestChunkGo_EmptyFile(t *testing.T) {
+	chunks := ChunkFile("empty.go", "")
+	// Should not panic; may return nil or empty slice.
+	_ = chunks
+}
+
+func TestChunkGo_PackageOnlyFile(t *testing.T) {
+	src := "package main\n"
+	chunks := ChunkFile("pkg.go", src)
+	_ = chunks // must not panic
+}
+
+// ---------------------------------------------------------------------------
+// chunkWindow — non-Go fallback
+// ---------------------------------------------------------------------------
+
+func TestChunkWindow_Python(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < 100; i++ {
+		sb.WriteString("# Python line\nresult = some_function(arg)\n")
+	}
+	chunks := ChunkFile("script.py", sb.String())
+	if len(chunks) == 0 {
+		t.Fatal("expected chunks from Python file")
+	}
+	// No chunk should end mid-line (last char should be '\n' or be the last char of file).
+	for _, c := range chunks {
+		if len(c.Text) == 0 {
+			t.Error("empty chunk text")
+		}
+	}
+}
+
+func TestChunkWindow_Markdown(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < 50; i++ {
+		sb.WriteString("## Section\n\nSome content here.\n\n")
+	}
+	chunks := ChunkFile("README.md", sb.String())
+	if len(chunks) == 0 {
+		t.Fatal("expected chunks from markdown file")
+	}
+}
+
+func TestChunkFile_UnknownExt_Nil(t *testing.T) {
+	chunks := ChunkFile("file.xyz", "some random content")
+	if chunks != nil {
+		t.Error("expected nil for unknown extension")
+	}
+}
+
+func TestChunkFile_IDs_Unique(t *testing.T) {
+	var sb strings.Builder
+	for i := 0; i < 10; i++ {
+		sb.WriteString("func Fn() {}\n\n")
+	}
+	chunks := ChunkFile("ids.go", sb.String())
+	seen := map[string]bool{}
+	for _, c := range chunks {
+		if seen[c.ID] {
+			t.Errorf("duplicate chunk ID: %s", c.ID)
+		}
+		seen[c.ID] = true
+	}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "close-wiki"
-version = "0.7.3"
+version = "0.8.1"
 description = "Agentic repo-to-wiki: scan any repository into a knowledge store with wiki pages, diagrams, and grounded Q&A."
 readme = "README.md"
 requires-python = ">=3.11"


### PR DESCRIPTION
## Summary
Implements Issue #95.

- `chunkGo()`: splits at `func`/`type`/`var`/`const` boundaries (regex, zero CGO)
- Merges micro-segments < 200 runes, splits oversized via `chunkWindow`
- Accurate line numbers
- `chunkWindow()` extracted as named function
- 8 new Go unit tests; all 19 `rag` tests pass ✅
- v0.8.1