### PR TITLE
fix(#87): unify shard token budget — Python 12K→40K + env var override

### DIFF
--- a/RELEASE-NOTES.md
+++ b/RELEASE-NOTES.md
@@ -1,5 +1,43 @@
 # Release Notes
 
+## v0.8.2 — Unified Shard Token Budget (Issue #87)
+
+### What's new
+
+#### Python + Go shard budget aligned at 40 000 tokens
+- Python `_DEFAULT_TOKEN_BUDGET` raised from **12 000 → 40 000** — matches Go runtime
+- `REKIPEDIA_SHARD_TOKEN_BUDGET` env var now honoured in **both** Python and Go
+- Go: `resolveTokenBudget()` helper checks env var → explicit override → default (40 000)
+- Invalid env var: Python raises `ValueError`; Go silently falls back to default
+- 3 new Python tests + 10 new Go tests — all pass ✅
+
+---
+
+## v0.8.1 — Go AST-Aware Chunking (Issue #95)
+
+### What's new
+
+#### Symbol-boundary chunking for `.go` files
+- `chunkGo()` replaces naive sliding-window; detects `func`/`type`/`var`/`const` boundaries
+- Merges micro-segments < 200 runes; splits oversized via `chunkWindow`
+- `chunkWindow()` extracted as named reusable function
+- 8 new Go unit tests; all 19 `rag` package tests pass ✅
+
+---
+
+## v0.8.0 — Agentic ReAct Ask Loop (Issue #94)
+
+### What's new
+
+#### `reki ask --agentic` / `close-wiki ask --agentic`
+- ReAct loop — LLM iterates up to 5 times before delivering final answer
+- Tools: `search_code`, `get_symbol`, `get_page`, `get_relationships`
+- `LLMClient.call_with_tools()` (Python + Go)
+- `REKIPEDIA_AGENTIC=1` env var support
+- 10 new unit tests ✅
+
+---
+
 ## v0.7.3 — is_implementation Heuristic in Planner & Token-Aware File Skip
 
 ### What's new

--- a/go/cmd/close-wiki/cmd/root.go
+++ b/go/cmd/close-wiki/cmd/root.go
@@ -11,7 +11,7 @@ import (
 
 // Version is injected at build time via -ldflags.
 var (
-	version = "dev"
+	version = "0.8.2"
 	commit  = "none"
 	date    = "unknown"
 )

--- a/go/internal/orchestrator/sharding.go
+++ b/go/internal/orchestrator/sharding.go
@@ -2,16 +2,32 @@
 package orchestrator
 
 import (
+	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/unrealandychan/close-wiki/internal/models"
 )
 
 const (
-	bytesPerToken       = 4   // ~4 bytes per token
-	defaultTokenBudget  = 40000 // max tokens per shard
+	bytesPerToken      = 4     // ~4 bytes per token
+	defaultTokenBudget = 40000 // max tokens per shard; aligned with Python runtime
 )
+
+// resolveTokenBudget returns the effective token budget.
+// Checks REKIPEDIA_SHARD_TOKEN_BUDGET env var first; falls back to defaultTokenBudget.
+func resolveTokenBudget(override int) int {
+	if override > 0 {
+		return override
+	}
+	if v := os.Getenv("REKIPEDIA_SHARD_TOKEN_BUDGET"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return defaultTokenBudget
+}
 
 // ShardPlanner groups FileManifest entries into shards that fit within a token budget.
 type ShardPlanner struct {
@@ -19,12 +35,9 @@ type ShardPlanner struct {
 }
 
 // NewShardPlanner creates a ShardPlanner with the given token budget.
-// If budget ≤ 0, the default (40 000 tokens) is used.
+// If budget ≤ 0, checks REKIPEDIA_SHARD_TOKEN_BUDGET env var, then falls back to 40 000.
 func NewShardPlanner(budget int) *ShardPlanner {
-	if budget <= 0 {
-		budget = defaultTokenBudget
-	}
-	return &ShardPlanner{budget: budget}
+	return &ShardPlanner{budget: resolveTokenBudget(budget)}
 }
 
 // Plan groups files by top-level directory and splits groups that exceed the budget.

--- a/go/internal/orchestrator/sharding_test.go
+++ b/go/internal/orchestrator/sharding_test.go
@@ -1,0 +1,109 @@
+package orchestrator
+
+import (
+	"os"
+	"testing"
+
+	"github.com/unrealandychan/close-wiki/internal/models"
+)
+
+func makeFiles(n int, sizeBytes int64) []models.FileManifest {
+	files := make([]models.FileManifest, n)
+	for i := range files {
+		files[i] = models.FileManifest{
+			Path:      "src/file" + string(rune('A'+i)) + ".go",
+			SHA256:    "abc",
+			SizeBytes: sizeBytes,
+		}
+	}
+	return files
+}
+
+// ---------------------------------------------------------------------------
+// Issue #87: default budget alignment + env var override
+// ---------------------------------------------------------------------------
+
+func TestDefaultTokenBudget_Is40000(t *testing.T) {
+	if defaultTokenBudget != 40000 {
+		t.Errorf("expected defaultTokenBudget=40000, got %d", defaultTokenBudget)
+	}
+}
+
+func TestResolveTokenBudget_ExplicitOverride(t *testing.T) {
+	got := resolveTokenBudget(8000)
+	if got != 8000 {
+		t.Errorf("expected 8000, got %d", got)
+	}
+}
+
+func TestResolveTokenBudget_EnvVar(t *testing.T) {
+	t.Setenv("REKIPEDIA_SHARD_TOKEN_BUDGET", "25000")
+	got := resolveTokenBudget(0)
+	if got != 25000 {
+		t.Errorf("expected 25000 from env, got %d", got)
+	}
+}
+
+func TestResolveTokenBudget_InvalidEnvFallsBack(t *testing.T) {
+	t.Setenv("REKIPEDIA_SHARD_TOKEN_BUDGET", "notanumber")
+	got := resolveTokenBudget(0)
+	if got != defaultTokenBudget {
+		t.Errorf("expected fallback %d on invalid env, got %d", defaultTokenBudget, got)
+	}
+}
+
+func TestResolveTokenBudget_NoEnvFallsBack(t *testing.T) {
+	os.Unsetenv("REKIPEDIA_SHARD_TOKEN_BUDGET")
+	got := resolveTokenBudget(0)
+	if got != defaultTokenBudget {
+		t.Errorf("expected default %d, got %d", defaultTokenBudget, got)
+	}
+}
+
+func TestNewShardPlanner_UsesEnvVar(t *testing.T) {
+	t.Setenv("REKIPEDIA_SHARD_TOKEN_BUDGET", "5000")
+	sp := NewShardPlanner(0)
+	if sp.budget != 5000 {
+		t.Errorf("expected budget 5000 from env, got %d", sp.budget)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Existing plan behaviour (regression)
+// ---------------------------------------------------------------------------
+
+func TestPlan_Empty(t *testing.T) {
+	sp := NewShardPlanner(40000)
+	if got := sp.Plan(nil); got != nil {
+		t.Error("expected nil for empty input")
+	}
+}
+
+func TestPlan_SingleFile(t *testing.T) {
+	sp := NewShardPlanner(40000)
+	shards := sp.Plan(makeFiles(1, 1000))
+	if len(shards) != 1 {
+		t.Errorf("expected 1 shard, got %d", len(shards))
+	}
+}
+
+func TestPlan_SplitsOversizedGroup(t *testing.T) {
+	// 3 files × 4000 bytes = 1000 tokens each; budget = 1000 → each file = own shard
+	sp := NewShardPlanner(1000)
+	shards := sp.Plan(makeFiles(3, 4000))
+	if len(shards) != 3 {
+		t.Errorf("expected 3 shards, got %d", len(shards))
+	}
+}
+
+func TestPlan_ShardIDs_Unique(t *testing.T) {
+	sp := NewShardPlanner(1000)
+	shards := sp.Plan(makeFiles(5, 4001))
+	seen := map[string]bool{}
+	for _, s := range shards {
+		if seen[s.ShardID] {
+			t.Errorf("duplicate shard ID: %s", s.ShardID)
+		}
+		seen[s.ShardID] = true
+	}
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "close-wiki"
-version = "0.7.3"
+version = "0.8.2"
 description = "Agentic repo-to-wiki: scan any repository into a knowledge store with wiki pages, diagrams, and grounded Q&A."
 readme = "README.md"
 requires-python = ">=3.11"

--- a/src/close_wiki/orchestrator/sharding.py
+++ b/src/close_wiki/orchestrator/sharding.py
@@ -1,14 +1,17 @@
 """Shard planner: partition FileManifest lists into token-budget shards."""
 from __future__ import annotations
 
+import os
 from pathlib import Path
 
 from close_wiki.models.contracts import FileManifest, LLMConfig, Shard
 
 # Rough tokens-per-byte ratio (4 chars ≈ 1 token for code)
-_BYTES_PER_TOKEN = 4
-# Max tokens per shard before a new shard is started
-_DEFAULT_TOKEN_BUDGET = 12_000
+_BYTES_PER_TOKEN: int = 4
+# Max tokens per shard before a new shard is started.
+# Aligned with Go runtime (was 12 000; raised to 40 000 for modern models).
+# Override via REKIPEDIA_SHARD_TOKEN_BUDGET env var.
+_DEFAULT_TOKEN_BUDGET: int = int(os.environ.get("REKIPEDIA_SHARD_TOKEN_BUDGET", "40000"))
 
 
 class ShardPlanner:

--- a/tests/test_sharding.py
+++ b/tests/test_sharding.py
@@ -61,3 +61,39 @@ def test_llm_config_propagated():
     planner = ShardPlanner()
     shards = planner.plan([_MINI_FILES[0]], cfg)
     assert shards[0].llm.model == "custom/model"
+
+
+# ---------------------------------------------------------------------------
+# Issue #87: unified token budget + env var override
+# ---------------------------------------------------------------------------
+
+def test_default_budget_is_40000():
+    """After #87, default budget must be 40 000 (aligned with Go runtime)."""
+    from close_wiki.orchestrator.sharding import _DEFAULT_TOKEN_BUDGET
+    assert _DEFAULT_TOKEN_BUDGET == 40_000
+
+
+def test_env_var_overrides_budget(monkeypatch):
+    """REKIPEDIA_SHARD_TOKEN_BUDGET env var should override the default."""
+    import importlib, close_wiki.orchestrator.sharding as m
+    monkeypatch.setenv("REKIPEDIA_SHARD_TOKEN_BUDGET", "20000")
+    importlib.reload(m)
+    assert m._DEFAULT_TOKEN_BUDGET == 20_000
+    # Restore
+    monkeypatch.delenv("REKIPEDIA_SHARD_TOKEN_BUDGET", raising=False)
+    importlib.reload(m)
+
+
+def test_env_var_invalid_falls_back(monkeypatch):
+    """Non-integer REKIPEDIA_SHARD_TOKEN_BUDGET should raise ValueError (not silently use 0)."""""
+    import importlib, close_wiki.orchestrator.sharding as m
+    monkeypatch.setenv("REKIPEDIA_SHARD_TOKEN_BUDGET", "notanumber")
+    try:
+        importlib.reload(m)
+        # ValueError expected from int("notanumber")
+        assert False, "Expected ValueError"
+    except ValueError:
+        pass
+    finally:
+        monkeypatch.delenv("REKIPEDIA_SHARD_TOKEN_BUDGET", raising=False)
+        importlib.reload(m)


### PR DESCRIPTION
## Summary
Fixes Issue #87.

- Python `_DEFAULT_TOKEN_BUDGET`: 12 000 → **40 000** (aligned with Go)
- `REKIPEDIA_SHARD_TOKEN_BUDGET` env var honoured in both Python and Go
- Go: `resolveTokenBudget()` helper added
- 3 new Python tests + 10 new Go sharding tests
- All tests pass ✅
- v0.8.2