### PR TITLE
fix(ask): early API key validation with helpful error (closes #156)

### DIFF
--- a/src/rekipedia/cli/ask.py
+++ b/src/rekipedia/cli/ask.py
@@ -253,17 +253,27 @@ def ask_cmd(
     llm_config = _build_llm_config(repo, model)
 
     # ── Early API key validation (issue #156) ────────────────────────────────
-    _has_api_key = (
+    model_name = os.environ.get("REKIPEDIA_MODEL") or llm_config.model
+    base_url = os.environ.get("REKIPEDIA_BASE_URL") or llm_config.base_url
+
+    _has_api_key = bool(
         os.environ.get("REKIPEDIA_API_KEY")
         or os.environ.get("OPENAI_API_KEY")
         or llm_config.api_key
     )
-    if not _has_api_key:
+    _needs_api_key = not model_name.startswith("ollama/") and not bool(base_url)
+
+    if _needs_api_key and not _has_api_key:
         console.print("[bold red]✗[/bold red]  No LLM API key found.")
-        console.print("   Set [bold]REKIPEDIA_API_KEY[/bold] (or [bold]OPENAI_API_KEY[/bold]) before running [bold]reki ask[/bold].")
-        console.print("   Other providers: [bold]REKIPEDIA_MODEL[/bold]=claude-... [bold]REKIPEDIA_API_KEY[/bold]=sk-ant-... reki ask ...")
+        console.print(
+            "   Set [bold]REKIPEDIA_API_KEY[/bold] (or [bold]OPENAI_API_KEY[/bold]) before running [bold]reki ask[/bold]."
+        )
+        console.print(
+            "   Other providers: [bold]REKIPEDIA_MODEL[/bold]=anthropic/claude-... [bold]REKIPEDIA_API_KEY[/bold]=sk-ant-... reki ask ..."
+        )
         console.print("   Tip: run [bold]`reki scan . --no-llm`[/bold] for static analysis without an API key.")
         sys.exit(1)
+    # ─────────────────────────────────────────────────────────────────────────
     # ─────────────────────────────────────────────────────────────────────────
 
     if no_rewrite:

--- a/src/rekipedia/cli/ask.py
+++ b/src/rekipedia/cli/ask.py
@@ -246,9 +246,25 @@ def ask_cmd(
     import datetime
     import json as _json
 
+    import sys
+
     repo = repo.resolve()
     output_dir = (output_dir or repo / ".rekipedia").resolve()
     llm_config = _build_llm_config(repo, model)
+
+    # ── Early API key validation (issue #156) ────────────────────────────────
+    _has_api_key = (
+        os.environ.get("REKIPEDIA_API_KEY")
+        or os.environ.get("OPENAI_API_KEY")
+        or llm_config.api_key
+    )
+    if not _has_api_key:
+        console.print("[bold red]✗[/bold red]  No LLM API key found.")
+        console.print("   Set [bold]REKIPEDIA_API_KEY[/bold] (or [bold]OPENAI_API_KEY[/bold]) before running [bold]reki ask[/bold].")
+        console.print("   Other providers: [bold]REKIPEDIA_MODEL[/bold]=claude-... [bold]REKIPEDIA_API_KEY[/bold]=sk-ant-... reki ask ...")
+        console.print("   Tip: run [bold]`reki scan . --no-llm`[/bold] for static analysis without an API key.")
+        sys.exit(1)
+    # ─────────────────────────────────────────────────────────────────────────
 
     if no_rewrite:
         import os

--- a/src/rekipedia/cli/ask.py
+++ b/src/rekipedia/cli/ask.py
@@ -259,6 +259,9 @@ def ask_cmd(
     _has_api_key = bool(
         os.environ.get("REKIPEDIA_API_KEY")
         or os.environ.get("OPENAI_API_KEY")
+        or os.environ.get("ANTHROPIC_API_KEY")
+        or os.environ.get("GEMINI_API_KEY")
+        or os.environ.get("GOOGLE_API_KEY")
         or llm_config.api_key
     )
     _needs_api_key = not model_name.startswith("ollama/") and not bool(base_url)
@@ -277,7 +280,6 @@ def ask_cmd(
     # ─────────────────────────────────────────────────────────────────────────
 
     if no_rewrite:
-        import os
         os.environ["REKIPEDIA_QUERY_REWRITE"] = "0"
 
     # Resolve streaming preference: --no-stream flag OR REKIPEDIA_STREAM=0


### PR DESCRIPTION
Closes #156

Adds early validation before any LLM call in reki ask. If no API key is found, prints a clear actionable error and exits cleanly instead of crashing with a litellm traceback.