### PR TITLE
docs: --no-llm quick start + multi-provider LLM setup (closes #158, closes #159)

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,24 @@ pip install "rekipedia[rag]"   # + semantic search (FAISS)
 
 ---
 
+## Quick Start — No API Key Needed
+
+Run a full static analysis without any LLM API key:
+
+```bash
+pip install rekipedia
+reki scan . --no-llm   # ~5-10s, zero API calls
+reki onboard .         # architecture overview
+reki tour .            # guided walkthrough by dependency depth
+reki domain .          # business domain layer map
+reki diff .            # impact analysis on changed files
+reki export . --format md  # export full wiki to markdown
+```
+
+> **Note:** `reki ask` (AI Q&A) requires an LLM API key. See [LLM Setup](#llm-setup) below.
+
+---
+
 ## Core commands
 
 | Command | What it does |
@@ -50,7 +68,18 @@ pip install "rekipedia[rag]"   # + semantic search (FAISS)
 
 ---
 
-## LLM configuration
+## LLM Setup
+
+rekipedia uses [litellm](https://github.com/BerriAI/litellm) and supports any provider:
+
+| Provider | Example |
+|---|---|
+| OpenAI | `OPENAI_API_KEY=sk-... reki scan .` |
+| Anthropic Claude | `REKIPEDIA_MODEL=claude-3-5-sonnet-20241022 REKIPEDIA_API_KEY=sk-ant-... reki scan .` |
+| Google Gemini | `REKIPEDIA_MODEL=gemini/gemini-2.0-flash REKIPEDIA_API_KEY=AIza... reki scan .` |
+| OpenRouter | `REKIPEDIA_MODEL=openrouter/anthropic/claude-3.5-sonnet REKIPEDIA_API_KEY=sk-or-... reki scan .` |
+| Local Ollama (default) | `REKIPEDIA_MODEL=ollama/llama4 reki scan .` |
+| Azure OpenAI | `REKIPEDIA_MODEL=azure/gpt-4o REKIPEDIA_BASE_URL=https://your-resource.openai.azure.com REKIPEDIA_API_KEY=... reki scan .` |
 
 After `reki init`, edit `.rekipedia/config.yml`:
 
@@ -64,7 +93,11 @@ llm:
 
 Supported providers: Ollama, OpenAI, Anthropic, Gemini, any OpenAI-compatible endpoint.
 
-Key env vars: `REKIPEDIA_MODEL`, `REKIPEDIA_API_KEY`, `REKIPEDIA_BASE_URL`
+Environment variables:
+- `REKIPEDIA_MODEL` — litellm model string (default: `ollama/llama4`)
+- `REKIPEDIA_API_KEY` — API key for the chosen provider
+- `REKIPEDIA_BASE_URL` — custom base URL (for Azure, Ollama, proxies)
+- `REKIPEDIA_TIMEOUT` — LLM call timeout in seconds (default: 180)
 
 ---
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -62,6 +62,24 @@ brew install rekipedia
 
 ---
 
+## 快速开始——无需 API 密钥
+
+无需任何 LLM API 密钥即可执行完整静态分析：
+
+```bash
+pip install rekipedia
+reki scan . --no-llm   # ~5-10 秒，零 API 调用
+reki onboard .         # 架构总览
+reki tour .            # 依赖深度导览
+reki domain .          # 业务领域层次图
+reki diff .            # 变更影响分析
+reki export . --format md  # 导出完整 wiki 为 Markdown
+```
+
+> **注意：** `reki ask`（AI 问答）需要 LLM API 密钥。请参阅下方 [LLM 配置](#llm-配置)。
+
+---
+
 ## Python API
 
 在 Jupyter Notebook、CI 流水线或任意 Python 应用中以编程方式使用 rekipedia：
@@ -120,6 +138,23 @@ answer = await rekipedia.ask_async("/path/to/repo", "What is the entry point?")
 ---
 
 ## LLM 配置
+
+rekipedia 使用 [litellm](https://github.com/BerriAI/litellm)，支持任何提供商：
+
+| 提供商 | 示例 |
+|---|---|
+| OpenAI | `OPENAI_API_KEY=sk-... reki scan .` |
+| Anthropic Claude | `REKIPEDIA_MODEL=claude-3-5-sonnet-20241022 REKIPEDIA_API_KEY=sk-ant-... reki scan .` |
+| Google Gemini | `REKIPEDIA_MODEL=gemini/gemini-2.0-flash REKIPEDIA_API_KEY=AIza... reki scan .` |
+| OpenRouter | `REKIPEDIA_MODEL=openrouter/anthropic/claude-3.5-sonnet REKIPEDIA_API_KEY=sk-or-... reki scan .` |
+| 本地 Ollama（默认） | `REKIPEDIA_MODEL=ollama/llama4 reki scan .` |
+| Azure OpenAI | `REKIPEDIA_MODEL=azure/gpt-4o REKIPEDIA_BASE_URL=https://your-resource.openai.azure.com REKIPEDIA_API_KEY=... reki scan .` |
+
+环境变量：
+- `REKIPEDIA_MODEL` — litellm 模型字符串（默认：`ollama/llama4`）
+- `REKIPEDIA_API_KEY` — 所选提供商的 API 密钥
+- `REKIPEDIA_BASE_URL` — 自定义基础 URL（用于 Azure、Ollama、代理）
+- `REKIPEDIA_TIMEOUT` — LLM 调用超时秒数（默认：180）
 
 运行 `rekipedia init` 后，编辑 `.rekipedia/config.yml`：
 

--- a/README.zh-TW.md
+++ b/README.zh-TW.md
@@ -62,6 +62,24 @@ brew install rekipedia
 
 ---
 
+## 快速開始——無需 API 金鑰
+
+無需任何 LLM API 金鑰即可執行完整靜態分析：
+
+```bash
+pip install rekipedia
+reki scan . --no-llm   # ~5-10 秒，零 API 呼叫
+reki onboard .         # 架構總覽
+reki tour .            # 依賴深度導覽
+reki domain .          # 業務領域層次圖
+reki diff .            # 變更影響分析
+reki export . --format md  # 匯出完整 wiki 為 Markdown
+```
+
+> **注意：** `reki ask`（AI 問答）需要 LLM API 金鑰。請參閱下方 [LLM 設定](#llm-設定)。
+
+---
+
 ## Python API
 
 在 Jupyter 筆記本、CI 流水線或任何 Python 應用程式中以程式化方式使用 rekipedia：
@@ -120,6 +138,23 @@ answer = await rekipedia.ask_async("/path/to/repo", "What is the entry point?")
 ---
 
 ## LLM 設定
+
+rekipedia 使用 [litellm](https://github.com/BerriAI/litellm)，支援任何提供者：
+
+| 提供者 | 範例 |
+|---|---|
+| OpenAI | `OPENAI_API_KEY=sk-... reki scan .` |
+| Anthropic Claude | `REKIPEDIA_MODEL=claude-3-5-sonnet-20241022 REKIPEDIA_API_KEY=sk-ant-... reki scan .` |
+| Google Gemini | `REKIPEDIA_MODEL=gemini/gemini-2.0-flash REKIPEDIA_API_KEY=AIza... reki scan .` |
+| OpenRouter | `REKIPEDIA_MODEL=openrouter/anthropic/claude-3.5-sonnet REKIPEDIA_API_KEY=sk-or-... reki scan .` |
+| 本地 Ollama（預設） | `REKIPEDIA_MODEL=ollama/llama4 reki scan .` |
+| Azure OpenAI | `REKIPEDIA_MODEL=azure/gpt-4o REKIPEDIA_BASE_URL=https://your-resource.openai.azure.com REKIPEDIA_API_KEY=... reki scan .` |
+
+環境變數：
+- `REKIPEDIA_MODEL` — litellm 模型字串（預設：`ollama/llama4`）
+- `REKIPEDIA_API_KEY` — 所選提供者的 API 金鑰
+- `REKIPEDIA_BASE_URL` — 自訂基礎 URL（用於 Azure、Ollama、代理）
+- `REKIPEDIA_TIMEOUT` — LLM 呼叫逾時秒數（預設：180）
 
 執行 `rekipedia init` 後，編輯 `.rekipedia/config.yml`：
 

--- a/src/rekipedia/cli/scan.py
+++ b/src/rekipedia/cli/scan.py
@@ -50,7 +50,7 @@ def _run_with_refactor(repo: Path, output_dir: Path, verbose: bool) -> None:
 @click.option("--embed-provider", default=None, envvar="REKIPEDIA_EMBED_PROVIDER", help="Embedding provider prefix (e.g. openai, ollama, azure). Combined with --embed-model as 'provider/model'.")
 @click.option("--languages", "-l", default=None, help="Comma-separated list of languages to include, e.g. python,typescript,go. Default: all.")
 @click.option("--force", "-f", is_flag=True, default=False, help="Force re-scan even if a completed scan already exists in the DB.")
-@click.option("--no-llm", is_flag=True, default=False, help="Skip LLM enrichment for refactoring issues (static analysis only).")
+@click.option("--no-llm", is_flag=True, default=False, help="Skip all LLM calls — run static analysis only (zero API calls, ~5-10s). All commands except `reki ask` work without an API key.")
 @click.option("--stdout", "stdout_refactor", is_flag=True, default=False, help="Print REFACTOR.md to stdout after scan (useful for piping to Claude Code).")
 @click.option("--with-refactor", is_flag=True, default=False, help="Auto-generate REFACTOR.md after scan completes.")
 @click.option(


### PR DESCRIPTION
Closes #158
Closes #159

- Add Quick Start (no API key) section showcasing --no-llm workflow
- Add LLM Setup section documenting all supported providers via REKIPEDIA_MODEL/REKIPEDIA_API_KEY/REKIPEDIA_BASE_URL
- Update zh-TW and zh-CN READMEs if present