### PR TITLE
feat(ask): --brief flag for minimal token output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## [0.17.19] - 2026-05-26
+### Added
+- `reki ask --brief` / `REKIPEDIA_BRIEF=1` — compact answer mode (~150 tokens, 1 paragraph + file:line citations) closes #167

--- a/README.md
+++ b/README.md
@@ -68,6 +68,18 @@ reki export . --format md  # export full wiki to markdown
 
 ---
 
+### `reki ask` — Brief mode
+
+```bash
+# Brief mode — ~150 tokens, summary + citations only
+reki ask "what does Scanner.scan() do?" --brief
+
+# Or via env var (useful for piping)
+REKIPEDIA_BRIEF=1 reki ask "entry point?" | grep 'src/'
+```
+
+---
+
 ## LLM Setup
 
 rekipedia uses [litellm](https://github.com/BerriAI/litellm) and supports any provider:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rekipedia"
-version = "0.17.18"
+version = "0.17.19"
 description = "AI-powered wiki generator for any codebase"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/rekipedia/cli/ask.py
+++ b/src/rekipedia/cli/ask.py
@@ -95,6 +95,7 @@ def _answer_streaming(
     *,
     stream: bool = True,
     pinned_files: list[str] | None = None,
+    brief: bool = False,
 ) -> str | None:
     """Run one Q&A turn: spinner while waiting, then stream tokens via rich.Live.
 
@@ -131,6 +132,7 @@ def _answer_streaming(
                     llm_config=llm_config,
                     history=history,
                     pinned_context=pinned_files,
+                    brief=brief,
                 )
             except (RuntimeError, Exception) as exc:
                 console.print(f"[bold red]Error:[/bold red] {exc}")
@@ -149,6 +151,7 @@ def _answer_streaming(
             llm_config=llm_config,
             history=history,
             pinned_context=pinned_files,
+            brief=brief,
         )
     except (RuntimeError, Exception) as exc:
         console.print(f"[bold red]Error:[/bold red] {exc}")
@@ -214,6 +217,16 @@ def _answer_streaming(
     metavar="FILE[:SYMBOL]",
     help="Pin a file (or file:symbol) into context. Can be repeated.",
 )
+@click.option(
+    "--brief",
+    is_flag=True,
+    default=False,
+    envvar="REKIPEDIA_BRIEF",
+    help=(
+        "Brief mode — compact answer (~150 tokens): 1 paragraph + file:line citations. "
+        "Also controlled by REKIPEDIA_BRIEF=1 env var."
+    ),
+)
 def ask_cmd(
     question_arg: str | None,
     question: str | None,
@@ -225,6 +238,7 @@ def ask_cmd(
     no_rewrite: bool,
     no_stream: bool,
     pinned_files: tuple[str, ...],
+    brief: bool,
 ) -> None:
     """Interactive grounded Q&A about the scanned repository.
 
@@ -315,7 +329,7 @@ def ask_cmd(
     if single_question:
         # Single-shot mode (no session save)
         _print_banner()
-        _answer_streaming(single_question, repo, output_dir, llm_config, history=[], stream=use_stream, pinned_files=list(pinned_files))
+        _answer_streaming(single_question, repo, output_dir, llm_config, history=[], stream=use_stream, pinned_files=list(pinned_files), brief=brief)
         return
 
     # Interactive REPL
@@ -352,6 +366,6 @@ def ask_cmd(
             _save_session()
             break
 
-        answer = _answer_streaming(user_input, repo, output_dir, llm_config, history=list(history), stream=use_stream, pinned_files=list(pinned_files))
+        answer = _answer_streaming(user_input, repo, output_dir, llm_config, history=list(history), stream=use_stream, pinned_files=list(pinned_files), brief=brief)
         if answer:
             _append_history(user_input, answer)

--- a/src/rekipedia/orchestrator/run_ask.py
+++ b/src/rekipedia/orchestrator/run_ask.py
@@ -22,6 +22,13 @@ from rekipedia.storage.sqlite_store import SqliteStore
 
 _SYSTEM_PROMPT_PATH = Path(__file__).parent.parent / "prompts" / "ask_system.md"
 
+_BRIEF_SYSTEM_SUFFIX = (
+    "\n\n## BRIEF MODE\n"
+    "Answer in ONE paragraph (max 3 sentences). "
+    "Then list up to 5 file:line citations. "
+    "No prose beyond the paragraph."
+)
+
 # Approximate character budget for context (≈ 24 K tokens at ~4 chars/token).
 # Keeps us safely within the context window of most models.
 _CONTEXT_CHAR_BUDGET = 96_000
@@ -267,6 +274,7 @@ def _build_full_system(
     output_dir: Path,
     llm_config: LLMConfig,
     pinned_context: str = "",
+    brief: bool = False,
 ) -> str:
     """Assemble the system prompt + all context sources."""
     system_prompt = _SYSTEM_PROMPT_PATH.read_text(encoding="utf-8")
@@ -363,7 +371,10 @@ def _build_full_system(
             context_parts.append(sym_section)
 
     context = "\n\n".join(context_parts)
-    return f"{system_prompt}\n\n{context}"
+    full = f"{system_prompt}\n\n{context}"
+    if brief:
+        full += _BRIEF_SYSTEM_SUFFIX
+    return full
 
 
 # ---------------------------------------------------------------------------
@@ -377,6 +388,7 @@ def _prepare_ask(
     llm_config: LLMConfig | None,
     history: list[dict] | None,
     pinned_context: str = "",
+    brief: bool = False,
 ) -> tuple[LLMClient, str]:
     """Validate scan, build system prompt, and init LLM client.
 
@@ -386,7 +398,7 @@ def _prepare_ask(
     """
     llm_config = llm_config or LLMConfig()
     _verify_scan(output_dir, repo_root)
-    full_system = _build_full_system(question, output_dir, llm_config, pinned_context=pinned_context)
+    full_system = _build_full_system(question, output_dir, llm_config, pinned_context=pinned_context, brief=brief)
     client = LLMClient(llm_config)
     return client, full_system
 
@@ -402,6 +414,7 @@ def run_ask(
     llm_config: LLMConfig | None = None,
     history: list[dict] | None = None,
     pinned_context: list[str] | None = None,
+    brief: bool = False,
 ) -> str:
     """Answer *question* grounded in the knowledge store.
 
@@ -412,6 +425,8 @@ def run_ask(
         llm_config: LLM settings; defaults to LLMConfig().
         history: Previous conversation turns as [{role, content}, ...].
         pinned_context: List of file[:symbol] strings to pin into context.
+        brief: If True, use compact answer mode (~150 tokens, 1 paragraph + citations).
+               Also activated by REKIPEDIA_BRIEF=1 env var.
 
     Returns:
         The assistant's answer as a Markdown string.
@@ -420,11 +435,12 @@ def run_ask(
         RuntimeError: If no successful scan exists for the repo.
     """
     import os as _os
+    brief = brief or _os.environ.get("REKIPEDIA_BRIEF", "0") == "1"
     if _os.environ.get("REKIPEDIA_AGENT_ASK", "0") == "1":
         from rekipedia.orchestrator.agent_ask import agent_run_ask
         return agent_run_ask(question, repo_root, output_dir, llm_config, history)
     pinned_str = _load_pinned_context(pinned_context or [], repo_root)
-    client, full_system = _prepare_ask(question, repo_root, output_dir, llm_config, history, pinned_context=pinned_str)
+    client, full_system = _prepare_ask(question, repo_root, output_dir, llm_config, history, pinned_context=pinned_str, brief=brief)
     return client.call(question, system=full_system, history=history)
 
 
@@ -435,12 +451,15 @@ def stream_ask(
     llm_config: LLMConfig | None = None,
     history: list[dict] | None = None,
     pinned_context: list[str] | None = None,
+    brief: bool = False,
 ) -> Iterator[str]:
     """Answer *question* grounded in the knowledge store, streaming tokens.
 
     Identical to :func:`run_ask` except the final LLM call uses streaming
     and yields text chunks instead of returning a single string.
     """
+    import os as _os
+    brief = brief or _os.environ.get("REKIPEDIA_BRIEF", "0") == "1"
     pinned_str = _load_pinned_context(pinned_context or [], repo_root)
-    client, full_system = _prepare_ask(question, repo_root, output_dir, llm_config, history, pinned_context=pinned_str)
+    client, full_system = _prepare_ask(question, repo_root, output_dir, llm_config, history, pinned_context=pinned_str, brief=brief)
     return client.stream(question, system=full_system, history=history)

--- a/tests/test_ask_brief.py
+++ b/tests/test_ask_brief.py
@@ -1,0 +1,227 @@
+"""Tests for --brief flag and REKIPEDIA_BRIEF=1 env var in `reki ask`."""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from rekipedia.models.contracts import LLMConfig
+from rekipedia.orchestrator.run_ask import (
+    _build_full_system,
+    _BRIEF_SYSTEM_SUFFIX,
+    run_ask,
+    stream_ask,
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: minimal output_dir with store.db
+# ---------------------------------------------------------------------------
+
+def _make_output_dir(tmp_path: Path) -> Path:
+    output_dir = tmp_path / ".rekipedia"
+    output_dir.mkdir(parents=True, exist_ok=True)
+    (output_dir / "store.db").touch()
+    return output_dir
+
+
+# ---------------------------------------------------------------------------
+# _build_full_system — brief flag appends the suffix
+# ---------------------------------------------------------------------------
+
+class TestBuildFullSystemBrief:
+    def test_brief_false_does_not_append_suffix(self, tmp_path):
+        llm_config = LLMConfig(model="test/model")
+        with patch("rekipedia.orchestrator.run_ask._rag_chunks", return_value=[]):
+            result = _build_full_system("what is this?", tmp_path, llm_config, brief=False)
+        assert _BRIEF_SYSTEM_SUFFIX not in result
+
+    def test_brief_true_appends_suffix(self, tmp_path):
+        llm_config = LLMConfig(model="test/model")
+        with patch("rekipedia.orchestrator.run_ask._rag_chunks", return_value=[]):
+            result = _build_full_system("what is this?", tmp_path, llm_config, brief=True)
+        assert _BRIEF_SYSTEM_SUFFIX in result
+        assert "ONE paragraph" in result
+        assert "file:line citations" in result
+
+
+# ---------------------------------------------------------------------------
+# run_ask — brief=True passes suffix to LLM
+# ---------------------------------------------------------------------------
+
+class TestRunAskBrief:
+    def _setup(self, tmp_path):
+        output_dir = _make_output_dir(tmp_path)
+        llm_config = LLMConfig(model="test/model")
+        return output_dir, llm_config
+
+    def test_brief_true_includes_brief_suffix_in_system(self, tmp_path):
+        output_dir, llm_config = self._setup(tmp_path)
+        captured_system: list[str] = []
+
+        def _capture(prompt, system="", history=None):
+            captured_system.append(system)
+            return "short answer"
+
+        with patch("rekipedia.orchestrator.run_ask.SqliteStore") as MockStore:
+            MockStore.return_value.__enter__.return_value.get_latest_run_id.return_value = "run-1"
+            with patch("rekipedia.orchestrator.run_ask.LLMClient") as MockLLM:
+                MockLLM.return_value.call.side_effect = _capture
+                with patch("rekipedia.orchestrator.run_ask._rag_chunks", return_value=[]):
+                    run_ask("what is this?", tmp_path, output_dir, llm_config, brief=True)
+
+        assert captured_system, "LLMClient.call was never invoked"
+        assert _BRIEF_SYSTEM_SUFFIX in captured_system[0]
+
+    def test_brief_false_excludes_brief_suffix(self, tmp_path):
+        output_dir, llm_config = self._setup(tmp_path)
+        captured_system: list[str] = []
+
+        def _capture(prompt, system="", history=None):
+            captured_system.append(system)
+            return "long answer"
+
+        with patch("rekipedia.orchestrator.run_ask.SqliteStore") as MockStore:
+            MockStore.return_value.__enter__.return_value.get_latest_run_id.return_value = "run-1"
+            with patch("rekipedia.orchestrator.run_ask.LLMClient") as MockLLM:
+                MockLLM.return_value.call.side_effect = _capture
+                with patch("rekipedia.orchestrator.run_ask._rag_chunks", return_value=[]):
+                    run_ask("what is this?", tmp_path, output_dir, llm_config, brief=False)
+
+        assert captured_system
+        assert _BRIEF_SYSTEM_SUFFIX not in captured_system[0]
+
+    def test_env_var_rekipedia_brief_activates_brief(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("REKIPEDIA_BRIEF", "1")
+        output_dir, llm_config = self._setup(tmp_path)
+        captured_system: list[str] = []
+
+        def _capture(prompt, system="", history=None):
+            captured_system.append(system)
+            return "brief answer"
+
+        with patch("rekipedia.orchestrator.run_ask.SqliteStore") as MockStore:
+            MockStore.return_value.__enter__.return_value.get_latest_run_id.return_value = "run-1"
+            with patch("rekipedia.orchestrator.run_ask.LLMClient") as MockLLM:
+                MockLLM.return_value.call.side_effect = _capture
+                with patch("rekipedia.orchestrator.run_ask._rag_chunks", return_value=[]):
+                    run_ask("what is this?", tmp_path, output_dir, llm_config)
+
+        assert captured_system
+        assert _BRIEF_SYSTEM_SUFFIX in captured_system[0]
+
+    def test_env_var_0_does_not_activate_brief(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("REKIPEDIA_BRIEF", "0")
+        output_dir, llm_config = self._setup(tmp_path)
+        captured_system: list[str] = []
+
+        def _capture(prompt, system="", history=None):
+            captured_system.append(system)
+            return "normal answer"
+
+        with patch("rekipedia.orchestrator.run_ask.SqliteStore") as MockStore:
+            MockStore.return_value.__enter__.return_value.get_latest_run_id.return_value = "run-1"
+            with patch("rekipedia.orchestrator.run_ask.LLMClient") as MockLLM:
+                MockLLM.return_value.call.side_effect = _capture
+                with patch("rekipedia.orchestrator.run_ask._rag_chunks", return_value=[]):
+                    run_ask("what is this?", tmp_path, output_dir, llm_config)
+
+        assert captured_system
+        assert _BRIEF_SYSTEM_SUFFIX not in captured_system[0]
+
+
+# ---------------------------------------------------------------------------
+# stream_ask — brief=True also works
+# ---------------------------------------------------------------------------
+
+class TestStreamAskBrief:
+    def test_stream_brief_true_appends_suffix(self, tmp_path, monkeypatch):
+        monkeypatch.delenv("REKIPEDIA_BRIEF", raising=False)
+        output_dir = _make_output_dir(tmp_path)
+        llm_config = LLMConfig(model="test/model")
+        captured_system: list[str] = []
+
+        def _capture_stream(prompt, system="", history=None):
+            captured_system.append(system)
+            return iter(["brief answer"])
+
+        with patch("rekipedia.orchestrator.run_ask.SqliteStore") as MockStore:
+            MockStore.return_value.__enter__.return_value.get_latest_run_id.return_value = "run-1"
+            with patch("rekipedia.orchestrator.run_ask.LLMClient") as MockLLM:
+                MockLLM.return_value.stream.side_effect = _capture_stream
+                with patch("rekipedia.orchestrator.run_ask._rag_chunks", return_value=[]):
+                    chunks = list(stream_ask("what?", tmp_path, output_dir, llm_config, brief=True))
+
+        assert chunks == ["brief answer"]
+        assert captured_system
+        assert _BRIEF_SYSTEM_SUFFIX in captured_system[0]
+
+
+# ---------------------------------------------------------------------------
+# CLI — --brief flag is accepted
+# ---------------------------------------------------------------------------
+
+class TestAskCmdBriefFlag:
+    def test_brief_flag_accepted_by_cli(self, tmp_path):
+        from click.testing import CliRunner
+        from rekipedia.cli.ask import ask_cmd
+
+        runner = CliRunner()
+        with patch("rekipedia.cli.ask._answer_streaming") as mock_answer:
+            mock_answer.return_value = "brief answer"
+            result = runner.invoke(
+                ask_cmd,
+                [
+                    "--repo", str(tmp_path),
+                    "--output-dir", str(tmp_path),
+                    "--brief",
+                    "What is this?",
+                ],
+            )
+
+        # Should not fail with "No such option" error
+        assert "No such option" not in (result.output or "")
+        assert result.exit_code in (0, 1)  # 1 = missing scan, not CLI error
+
+    def test_brief_flag_passed_to_answer_streaming(self, tmp_path):
+        from click.testing import CliRunner
+        from rekipedia.cli.ask import ask_cmd
+
+        runner = CliRunner()
+        with patch("rekipedia.cli.ask._answer_streaming") as mock_answer:
+            mock_answer.return_value = "brief"
+            runner.invoke(
+                ask_cmd,
+                [
+                    "--repo", str(tmp_path),
+                    "--output-dir", str(tmp_path),
+                    "--brief",
+                    "What is this?",
+                ],
+            )
+
+        if mock_answer.called:
+            call_kwargs = mock_answer.call_args.kwargs
+            assert call_kwargs.get("brief") is True
+
+    def test_no_brief_flag_defaults_false(self, tmp_path):
+        from click.testing import CliRunner
+        from rekipedia.cli.ask import ask_cmd
+
+        runner = CliRunner()
+        with patch("rekipedia.cli.ask._answer_streaming") as mock_answer:
+            mock_answer.return_value = "normal"
+            runner.invoke(
+                ask_cmd,
+                [
+                    "--repo", str(tmp_path),
+                    "--output-dir", str(tmp_path),
+                    "What is this?",
+                ],
+            )
+
+        if mock_answer.called:
+            call_kwargs = mock_answer.call_args.kwargs
+            assert call_kwargs.get("brief") is False


### PR DESCRIPTION
Adds `--brief` flag and `REKIPEDIA_BRIEF=1` env var to `reki ask` for compact answers (~150 tokens). Closes #167.