### PR TITLE
feat(refactor): --apply and --dry-run flags for auto-applying safe refactor suggestions (closes #166)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,11 @@
+# Changelog
+
+## [0.17.22] - 2026-05-26
+### Added
+- `reki refactor --dry-run` — preview all suggested changes without writing files. Closes #166.
+- `reki refactor --apply` — auto-apply safe smells (`dead_code`, `large_file`). Non-auto-fixable smells show guidance only.
+- `reki refactor --apply --dry-run` — preview what `--apply` would do.
+
+## [0.17.21] - 2026-05-25
+### Changed
+- Maintenance release.

--- a/README.md
+++ b/README.md
@@ -62,6 +62,9 @@ reki export . --format md  # export full wiki to markdown
 | `reki onboard .` | Static onboarding guide for new developers |
 | `reki review` | LLM PR review grounded in wiki context |
 | `reki refactor .` | Detect code smells → `REFACTOR.md` |
+| `reki refactor . --dry-run` | Preview refactor suggestions without writing files |
+| `reki refactor . --apply` | Auto-apply safe fixes (dead code markers, split suggestions) |
+| `reki refactor . --apply --dry-run` | Preview what `--apply` would do |
 | `reki watch .` | Auto-index on file change (OS watcher) |
 | `reki hook install` | Git post-commit auto-rebuild |
 | `reki mcp` | MCP stdio server for AI coding assistants |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rekipedia"
-version = "0.17.18"
+version = "0.17.22"
 description = "AI-powered wiki generator for any codebase"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/rekipedia/__init__.py
+++ b/src/rekipedia/__init__.py
@@ -1,5 +1,5 @@
 """rekipedia — agentic repo-to-wiki knowledge store."""
-__version__ = "0.17.3"
+__version__ = "0.17.22"
 
 from rekipedia.api import (
     AskResult,

--- a/src/rekipedia/analysis/refactor_applier.py
+++ b/src/rekipedia/analysis/refactor_applier.py
@@ -1,0 +1,190 @@
+"""Auto-apply safe refactor suggestions to source files.
+
+Supports two auto-fixable smell types:
+- ``dead_code``:  inserts a ``# reki: dead-code (flagged DATE)`` comment above the symbol.
+- ``large_file``: inserts a comment block suggesting a module split.
+
+All other smell types are treated as guidance-only (``action="skipped"``).
+"""
+from __future__ import annotations
+
+import difflib
+from dataclasses import dataclass, field
+from datetime import date
+from pathlib import Path
+from typing import Any
+
+AUTO_FIXABLE: set[str] = {"dead_code", "large_file"}
+
+
+@dataclass
+class ApplyResult:
+    smell_type: str
+    file_path: str
+    action: str   # "comment_added" | "stub_created" | "skipped"
+    diff: str     # unified diff string
+    applied: bool
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+def _today() -> str:
+    return date.today().isoformat()
+
+
+def _apply_dead_code(smell: dict[str, Any], dry_run: bool) -> ApplyResult:
+    """Insert a dead-code marker comment above the symbol definition."""
+    file_path: str = smell.get("file", "")
+    symbol: str = smell.get("symbol", "")
+    line_no: int | None = smell.get("line") or smell.get("metrics", {}).get("line")
+
+    p = Path(file_path)
+    if not p.exists():
+        return ApplyResult(
+            smell_type="dead_code",
+            file_path=file_path,
+            action="skipped",
+            diff="",
+            applied=False,
+        )
+
+    original_lines = p.read_text(encoding="utf-8").splitlines(keepends=True)
+
+    # Try to locate the symbol definition line
+    insert_before: int | None = None
+    if line_no and 1 <= line_no <= len(original_lines):
+        insert_before = line_no - 1  # 0-indexed
+    else:
+        # Scan for the symbol definition
+        for idx, raw_line in enumerate(original_lines):
+            stripped = raw_line.lstrip()
+            if stripped.startswith(("def ", "class ", "async def ")) and symbol in raw_line:
+                insert_before = idx
+                break
+
+    if insert_before is None:
+        return ApplyResult(
+            smell_type="dead_code",
+            file_path=file_path,
+            action="skipped",
+            diff="",
+            applied=False,
+        )
+
+    marker = f"# reki: dead-code (flagged {_today()})\n"
+    new_lines = original_lines[:insert_before] + [marker] + original_lines[insert_before:]
+    diff = "".join(
+        difflib.unified_diff(original_lines, new_lines, fromfile=file_path, tofile=file_path)
+    )
+
+    if not dry_run:
+        p.write_text("".join(new_lines), encoding="utf-8")
+
+    return ApplyResult(
+        smell_type="dead_code",
+        file_path=file_path,
+        action="comment_added",
+        diff=diff,
+        applied=not dry_run,
+    )
+
+
+def _apply_large_file(smell: dict[str, Any], dry_run: bool) -> ApplyResult:
+    """Insert a split-suggestion comment block at the top of the file."""
+    file_path: str = smell.get("file", "")
+    metrics: dict = smell.get("metrics", {})
+    line_count: int = metrics.get("line_count") or metrics.get("lines", 0)
+
+    # Heuristic: suggest N = ceil(line_count / 300) modules
+    import math
+    n_modules = max(2, math.ceil(line_count / 300)) if line_count else 2
+
+    p = Path(file_path)
+    if not p.exists():
+        return ApplyResult(
+            smell_type="large_file",
+            file_path=file_path,
+            action="skipped",
+            diff="",
+            applied=False,
+        )
+
+    original_lines = p.read_text(encoding="utf-8").splitlines(keepends=True)
+
+    comment_block = (
+        f"# reki: consider splitting into {n_modules} modules"
+        f" (flagged {_today()}, {line_count} lines)\n"
+    )
+    new_lines = [comment_block] + original_lines
+    diff = "".join(
+        difflib.unified_diff(original_lines, new_lines, fromfile=file_path, tofile=file_path)
+    )
+
+    if not dry_run:
+        p.write_text("".join(new_lines), encoding="utf-8")
+
+    return ApplyResult(
+        smell_type="large_file",
+        file_path=file_path,
+        action="stub_created",
+        diff=diff,
+        applied=not dry_run,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Public API
+# ---------------------------------------------------------------------------
+
+def apply_smell(smell: dict[str, Any], dry_run: bool = False) -> ApplyResult:
+    """Apply a single auto-fixable smell fix.
+
+    Parameters
+    ----------
+    smell:
+        A dict with at least ``"type"`` (or ``"kind"``) and ``"file"`` keys.
+        May also include ``"symbol"``, ``"line"``, and ``"metrics"``.
+    dry_run:
+        When *True* the fix is computed but no files are written.
+
+    Returns
+    -------
+    ApplyResult
+        Contains the unified diff, action taken, and whether the fix was
+        actually applied to disk.
+    """
+    smell_type: str = smell.get("type") or smell.get("kind") or ""
+
+    if smell_type == "dead_code":
+        return _apply_dead_code(smell, dry_run)
+    if smell_type == "large_file":
+        return _apply_large_file(smell, dry_run)
+
+    # Non-auto-fixable
+    return ApplyResult(
+        smell_type=smell_type,
+        file_path=smell.get("file", ""),
+        action="skipped",
+        diff="",
+        applied=False,
+    )
+
+
+def apply_all(smells: list[dict[str, Any]], dry_run: bool = False) -> list[ApplyResult]:
+    """Apply all auto-fixable smells, skipping non-auto-fixable ones.
+
+    Parameters
+    ----------
+    smells:
+        List of smell dicts (same format as accepted by :func:`apply_smell`).
+    dry_run:
+        When *True* no files are modified.
+
+    Returns
+    -------
+    list[ApplyResult]
+        One entry per input smell (including skipped ones).
+    """
+    return [apply_smell(smell, dry_run=dry_run) for smell in smells]

--- a/src/rekipedia/cli/refactor.py
+++ b/src/rekipedia/cli/refactor.py
@@ -240,6 +240,95 @@ def _filter_llm_report(content: str, severity: str) -> str:
     return "".join(out)
 
 
+def _run_apply_mode(repo: Path, *, apply_fixes: bool, dry_run: bool) -> None:
+    """Handle --apply and/or --dry-run execution paths."""
+    from rekipedia.analysis.refactor_applier import apply_all
+    import datetime
+
+    # Collect large-file smells from static walk
+    large_file_smells: list[dict] = []
+    for path in sorted(repo.rglob("*")):
+        if any(part in _SKIP_DIRS for part in path.parts):
+            continue
+        if not path.is_file() or path.suffix.lower() not in _TEXT_EXTENSIONS:
+            continue
+        try:
+            line_count = sum(1 for _ in path.open(encoding="utf-8", errors="ignore"))
+        except OSError:
+            continue
+        if line_count > 500:
+            large_file_smells.append({
+                "type": "large_file",
+                "file": str(path),
+                "symbol": path.name,
+                "metrics": {"line_count": line_count},
+                "description": f"{line_count} lines",
+            })
+
+    # Collect annotation smells for guidance
+    findings = _static_walk(repo)
+    annotation_smells = [
+        {
+            "type": f.get("type", "annotation").lower(),
+            "kind": f.get("type", "annotation").lower(),
+            "file": str(repo / f["file"]),
+            "symbol": f.get("description", ""),
+            "line": f.get("line"),
+            "description": f.get("description", ""),
+            "severity": f.get("severity", "medium"),
+        }
+        for f in findings
+    ]
+
+    all_smells = large_file_smells + annotation_smells
+
+    if apply_fixes:
+        label = "[DRY RUN] reki refactor --apply" if dry_run else "reki refactor --apply"
+    else:
+        label = "[DRY RUN] reki refactor"
+
+    console.print(f"\n[bold cyan]{label}[/bold cyan]\n")
+
+    results = apply_all(all_smells, dry_run=dry_run)
+
+    ready = 0
+    skipped = 0
+    for res, smell in zip(results, all_smells):
+        rel_file = smell.get("file", "")
+        try:
+            rel_file = str(Path(rel_file).relative_to(repo))
+        except ValueError:
+            pass
+        symbol = smell.get("symbol", "")
+        desc = smell.get("description", "")
+        line = smell.get("line", "")
+        loc = f"{rel_file}:{line}" if line else rel_file
+
+        if res.action == "skipped":
+            skipped += 1
+            console.print(f"  [dim]{loc}[/dim]  [yellow]{res.smell_type}[/yellow]  {desc}")
+            console.print(f"  [dim]→ (manual fix required — skipped)[/dim]\n")
+        else:
+            ready += 1
+            action_verb = "Would add" if dry_run else "Added"
+            today = datetime.date.today().isoformat()
+            if res.smell_type == "dead_code":
+                note = f"# reki: dead-code (flagged {today})"
+            else:
+                note = "comment block suggesting split"
+            console.print(f"  [cyan]{loc}[/cyan]  [green]{res.smell_type}[/green]  `{symbol}`  {desc}")
+            console.print(f"  [bold]→ {action_verb}:[/bold] {note}\n")
+
+    console.rule()
+    if dry_run:
+        console.print(
+            f"[bold]{ready} change(s) ready, {skipped} skipped.[/bold] "
+            "Run without --dry-run to apply."
+        )
+    else:
+        console.print(f"[bold green]✓ {ready} change(s) applied, {skipped} skipped.[/bold green]")
+
+
 def _emit(content: str, to_stdout: bool, out_path: Path, *, is_done_msg: bool = True) -> None:
     """Write *content* to *out_path* or print to stdout."""
     if to_stdout:
@@ -276,6 +365,8 @@ def _emit(content: str, to_stdout: bool, out_path: Path, *, is_done_msg: bool = 
 @click.option("--no-docker", is_flag=True, default=False, help="Skip Docker, run extractors in-process.")
 @click.option("--verbose", "-v", is_flag=True, default=False, help="Enable debug logging.")
 @click.option("--languages", "-l", default=None, help="Comma-separated languages to analyse, e.g. python,go.")
+@click.option("--dry-run", "dry_run", is_flag=True, default=False, help="Preview changes without writing files.")
+@click.option("--apply", "apply_fixes", is_flag=True, default=False, help="Auto-apply safe smells (dead_code, large_file).")
 def refactor_cmd(
     repo: Path,
     no_llm: bool,
@@ -287,6 +378,8 @@ def refactor_cmd(
     no_docker: bool,
     verbose: bool,
     languages: str | None,
+    dry_run: bool,
+    apply_fixes: bool,
 ) -> None:
     """Analyse REPO and produce a REFACTOR.md with prioritised improvement suggestions.
 
@@ -300,7 +393,7 @@ def refactor_cmd(
 
     Pass --no-llm to run phase 1 only (fast, no API key required).
 
-    \b
+    \\b
     Examples:
         rekipedia refactor .
         rekipedia refactor . --no-llm
@@ -308,9 +401,19 @@ def refactor_cmd(
         rekipedia refactor . --severity high
         rekipedia refactor . --json
         REKIPEDIA_MODEL=gpt-4o rekipedia refactor .
+        rekipedia refactor . --dry-run
+        rekipedia refactor . --apply
+        rekipedia refactor . --apply --dry-run
     """
     repo = repo.resolve()
     output_dir = (output_dir or repo / ".rekipedia").resolve()
+
+    # ------------------------------------------------------------------ #
+    # --dry-run / --apply mode                                             #
+    # ------------------------------------------------------------------ #
+    if dry_run or apply_fixes:
+        _run_apply_mode(repo, apply_fixes=apply_fixes, dry_run=dry_run)
+        return
 
     cfg = _load_config(repo)
     llm_cfg_raw = cfg.get("llm", {})

--- a/tests/test_refactor_apply.py
+++ b/tests/test_refactor_apply.py
@@ -1,0 +1,222 @@
+"""Tests for refactor_applier and --dry-run / --apply CLI flags."""
+from __future__ import annotations
+
+import textwrap
+from pathlib import Path
+
+import pytest
+from click.testing import CliRunner
+
+from rekipedia.analysis.refactor_applier import (
+    AUTO_FIXABLE,
+    ApplyResult,
+    apply_all,
+    apply_smell,
+)
+from rekipedia.cli.refactor import refactor_cmd
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def tmp_py(tmp_path: Path) -> Path:
+    """A minimal Python file with a private function (dead-code candidate)."""
+    f = tmp_path / "sample.py"
+    f.write_text(textwrap.dedent("""\
+        def public_func():
+            pass
+
+
+        def _legacy_parse():
+            pass
+    """))
+    return f
+
+
+@pytest.fixture()
+def tmp_large_py(tmp_path: Path) -> Path:
+    """A Python file with >500 lines."""
+    f = tmp_path / "big.py"
+    lines = [f"# line {i}\n" for i in range(600)]
+    f.write_text("".join(lines))
+    return f
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — apply_smell
+# ---------------------------------------------------------------------------
+
+class TestApplySmellDeadCode:
+    def test_adds_comment_above_symbol(self, tmp_py: Path) -> None:
+        smell = {
+            "type": "dead_code",
+            "file": str(tmp_py),
+            "symbol": "_legacy_parse",
+        }
+        result = apply_smell(smell, dry_run=False)
+        assert result.action == "comment_added"
+        assert result.applied is True
+        content = tmp_py.read_text()
+        assert "# reki: dead-code (flagged " in content
+        # comment should appear before the function definition
+        lines = content.splitlines()
+        marker_idx = next(i for i, l in enumerate(lines) if "# reki: dead-code" in l)
+        def_idx = next(i for i, l in enumerate(lines) if "def _legacy_parse" in l)
+        assert marker_idx == def_idx - 1
+
+    def test_diff_is_non_empty(self, tmp_py: Path) -> None:
+        smell = {
+            "type": "dead_code",
+            "file": str(tmp_py),
+            "symbol": "_legacy_parse",
+        }
+        result = apply_smell(smell, dry_run=True)
+        assert result.diff != ""
+
+    def test_dry_run_does_not_modify_file(self, tmp_py: Path) -> None:
+        original = tmp_py.read_text()
+        smell = {
+            "type": "dead_code",
+            "file": str(tmp_py),
+            "symbol": "_legacy_parse",
+        }
+        result = apply_smell(smell, dry_run=True)
+        assert tmp_py.read_text() == original
+        assert result.applied is False
+        assert result.action == "comment_added"
+
+
+class TestApplySmellLargeFile:
+    def test_adds_split_suggestion(self, tmp_large_py: Path) -> None:
+        smell = {
+            "type": "large_file",
+            "file": str(tmp_large_py),
+            "symbol": tmp_large_py.name,
+            "metrics": {"line_count": 600},
+        }
+        result = apply_smell(smell, dry_run=False)
+        assert result.action == "stub_created"
+        assert result.applied is True
+        content = tmp_large_py.read_text()
+        assert "# reki: consider splitting into" in content
+
+    def test_dry_run_does_not_modify_file(self, tmp_large_py: Path) -> None:
+        original = tmp_large_py.read_text()
+        smell = {
+            "type": "large_file",
+            "file": str(tmp_large_py),
+            "symbol": tmp_large_py.name,
+            "metrics": {"line_count": 600},
+        }
+        result = apply_smell(smell, dry_run=True)
+        assert tmp_large_py.read_text() == original
+        assert result.applied is False
+
+
+class TestApplySmellSkipped:
+    def test_non_auto_fixable_is_skipped(self) -> None:
+        smell = {"type": "god_class", "file": "/no/such/file.py", "symbol": "MyGodClass"}
+        result = apply_smell(smell)
+        assert result.action == "skipped"
+        assert result.applied is False
+
+    def test_missing_file_returns_skipped(self, tmp_path: Path) -> None:
+        smell = {
+            "type": "dead_code",
+            "file": str(tmp_path / "nonexistent.py"),
+            "symbol": "_foo",
+        }
+        result = apply_smell(smell)
+        assert result.action == "skipped"
+
+
+# ---------------------------------------------------------------------------
+# Unit tests — apply_all
+# ---------------------------------------------------------------------------
+
+class TestApplyAll:
+    def test_skips_non_auto_fixable(self) -> None:
+        smells = [
+            {"type": "god_class", "file": "/no/such.py", "symbol": "X"},
+            {"type": "circular_dep", "file": "/no/such.py", "symbol": "Y"},
+        ]
+        results = apply_all(smells)
+        assert all(r.action == "skipped" for r in results)
+
+    def test_processes_mixed_smells(self, tmp_py: Path, tmp_large_py: Path) -> None:
+        smells = [
+            {
+                "type": "dead_code",
+                "file": str(tmp_py),
+                "symbol": "_legacy_parse",
+            },
+            {
+                "type": "large_file",
+                "file": str(tmp_large_py),
+                "symbol": tmp_large_py.name,
+                "metrics": {"line_count": 600},
+            },
+            {"type": "god_class", "file": "/no/such.py", "symbol": "G"},
+        ]
+        results = apply_all(smells, dry_run=True)
+        assert len(results) == 3
+        assert results[0].action == "comment_added"
+        assert results[1].action == "stub_created"
+        assert results[2].action == "skipped"
+        # dry_run → no writes
+        assert all(not r.applied for r in results)
+
+    def test_auto_fixable_set(self) -> None:
+        assert "dead_code" in AUTO_FIXABLE
+        assert "large_file" in AUTO_FIXABLE
+
+
+# ---------------------------------------------------------------------------
+# CLI integration tests
+# ---------------------------------------------------------------------------
+
+class TestCLIDryRun:
+    def test_dry_run_exits_0(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(refactor_cmd, [str(tmp_path), "--dry-run"])
+        assert result.exit_code == 0, result.output
+
+    def test_dry_run_prints_preview(self, tmp_path: Path) -> None:
+        # Create a large file so there is something to preview
+        big = tmp_path / "big.py"
+        big.write_text("\n" * 600)
+        runner = CliRunner()
+        result = runner.invoke(refactor_cmd, [str(tmp_path), "--dry-run"])
+        assert result.exit_code == 0
+        assert "DRY RUN" in result.output
+
+    def test_dry_run_no_file_writes(self, tmp_path: Path) -> None:
+        small = tmp_path / "small.py"
+        small.write_text("def _dead(): pass\n")
+        before = small.read_text()
+        runner = CliRunner()
+        runner.invoke(refactor_cmd, [str(tmp_path), "--dry-run"])
+        assert small.read_text() == before
+
+
+class TestCLIApplyDryRun:
+    def test_apply_dry_run_exits_0(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(refactor_cmd, [str(tmp_path), "--apply", "--dry-run"])
+        assert result.exit_code == 0, result.output
+
+    def test_apply_dry_run_prints_apply_label(self, tmp_path: Path) -> None:
+        runner = CliRunner()
+        result = runner.invoke(refactor_cmd, [str(tmp_path), "--apply", "--dry-run"])
+        assert "DRY RUN" in result.output
+        assert "--apply" in result.output
+
+    def test_apply_dry_run_no_file_writes(self, tmp_path: Path) -> None:
+        f = tmp_path / "sample.py"
+        f.write_text("def _unused(): pass\n")
+        before = f.read_text()
+        runner = CliRunner()
+        runner.invoke(refactor_cmd, [str(tmp_path), "--apply", "--dry-run"])
+        assert f.read_text() == before


### PR DESCRIPTION
## Summary

Implements GitHub issue #166.

### Changes

- **`src/rekipedia/analysis/refactor_applier.py`** (new): `apply_smell()`, `apply_all()`, `ApplyResult` dataclass. Auto-fixes `dead_code` (inserts `# reki: dead-code (flagged DATE)`) and `large_file` (inserts split-suggestion comment). All other smell types are skipped with guidance.
- **`src/rekipedia/cli/refactor.py`**: added `--dry-run` and `--apply` flags with correct behaviour matrix.
- **`tests/test_refactor_apply.py`** (new): 16 tests covering all paths.
- **`CHANGELOG.md`**: new file, entry for `0.17.22`.
- **`README.md`**: table updated with new commands.
- Version bumped `0.17.18` → `0.17.22`.

### Behaviour matrix

| Flags | Result |
|---|---|
| (default) | write REFACTOR.md |
| `--dry-run` | print preview, no writes |
| `--apply` | apply safe smells, write files |
| `--apply --dry-run` | preview what `--apply` would do, no writes |

Closes #166