### PR TITLE
feat: reki hotspots — hub and bridge node detection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,9 @@
+# Changelog
+
+All notable changes to rekipedia are documented here.
+
+## [0.17.21] - 2026-05-26
+
+### Added
+- `reki hotspots` command — identifies hub nodes (most connected) and bridge nodes (cross-boundary connectors) in the symbol graph. Supports `--top N` and `--format table|json|md`. Closes #165.
+- `reki scan --hotspots` — auto-generates `ARCHITECTURE.md` after scan completes and writes it to `.rekipedia/wiki/`.

--- a/README.md
+++ b/README.md
@@ -37,6 +37,9 @@ reki scan . --no-llm   # ~5-10s, zero API calls
 reki onboard .         # architecture overview
 reki tour .            # guided walkthrough by dependency depth
 reki domain .          # business domain layer map
+reki hotspots .        # find architectural hotspots (hub & bridge nodes)
+reki hotspots . --top 20 --format md > ARCHITECTURE.md  # export to markdown
+reki scan . --hotspots # auto-generate ARCHITECTURE.md after scan
 reki diff .            # impact analysis on changed files
 reki export . --format md  # export full wiki to markdown
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "rekipedia"
-version = "0.17.18"
+version = "0.17.21"
 description = "AI-powered wiki generator for any codebase"
 requires-python = ">=3.11"
 dependencies = [

--- a/src/rekipedia/analysis/graph_analysis.py
+++ b/src/rekipedia/analysis/graph_analysis.py
@@ -162,3 +162,114 @@ def _build_hub_nodes(
 
     scored.sort(key=lambda x: x["score"], reverse=True)
     return scored[:top_n]
+
+
+def get_hub_nodes(store, run_id: str, top_n: int = 10) -> list[dict]:
+    """Return top N symbols by combined in+out degree.
+
+    Args:
+        store: SqliteStore instance (opened).
+        run_id: The scan run ID to query.
+        top_n: Number of top hub nodes to return.
+
+    Returns:
+        List of dicts with name, file, kind, in_degree, out_degree, total_degree.
+    """
+    from collections import defaultdict
+    relationships = store.get_all_relationships(run_id)
+    symbols = store.get_all_symbols(run_id)
+
+    in_deg: dict[str, int] = defaultdict(int)
+    out_deg: dict[str, int] = defaultdict(int)
+
+    for rel in relationships:
+        from_name = rel.get("from_", "") if isinstance(rel, dict) else (rel.from_ if hasattr(rel, "from_") else "")
+        to_name = rel.get("to", "") if isinstance(rel, dict) else (rel.to if hasattr(rel, "to") else "")
+        if from_name:
+            out_deg[from_name] += 1
+        if to_name:
+            in_deg[to_name] += 1
+
+    sym_lookup: dict[str, dict] = {}
+    for s in symbols:
+        name = s.get("name", "") if isinstance(s, dict) else (s.name if hasattr(s, "name") else "")
+        sym_lookup[name] = {
+            "file": s.get("file", "") if isinstance(s, dict) else (s.file if hasattr(s, "file") else ""),
+            "kind": s.get("kind", "") if isinstance(s, dict) else (s.kind if hasattr(s, "kind") else ""),
+        }
+
+    all_nodes = set(in_deg) | set(out_deg)
+    scored = []
+    for node in all_nodes:
+        i = in_deg[node]
+        o = out_deg[node]
+        sym = sym_lookup.get(node, {})
+        scored.append({
+            "name": node,
+            "file": sym.get("file", ""),
+            "kind": sym.get("kind", ""),
+            "in_degree": i,
+            "out_degree": o,
+            "total_degree": i + o,
+        })
+
+    scored.sort(key=lambda x: x["total_degree"], reverse=True)
+    return scored[:top_n]
+
+
+def get_bridge_nodes(store, run_id: str, top_n: int = 10) -> list[dict]:
+    """Approximate bridge nodes: symbols with high in-degree AND out-degree.
+
+    Uses in_degree * out_degree as an approximation for betweenness centrality.
+
+    Args:
+        store: SqliteStore instance (opened).
+        run_id: The scan run ID to query.
+        top_n: Number of top bridge nodes to return.
+
+    Returns:
+        List of dicts with name, file, kind, in_degree, out_degree, bridge_score.
+    """
+    from collections import defaultdict
+    relationships = store.get_all_relationships(run_id)
+    symbols = store.get_all_symbols(run_id)
+
+    in_deg: dict[str, int] = defaultdict(int)
+    out_deg: dict[str, int] = defaultdict(int)
+
+    for rel in relationships:
+        from_name = rel.get("from_", "") if isinstance(rel, dict) else (rel.from_ if hasattr(rel, "from_") else "")
+        to_name = rel.get("to", "") if isinstance(rel, dict) else (rel.to if hasattr(rel, "to") else "")
+        if from_name:
+            out_deg[from_name] += 1
+        if to_name:
+            in_deg[to_name] += 1
+
+    sym_lookup: dict[str, dict] = {}
+    for s in symbols:
+        name = s.get("name", "") if isinstance(s, dict) else (s.name if hasattr(s, "name") else "")
+        sym_lookup[name] = {
+            "file": s.get("file", "") if isinstance(s, dict) else (s.file if hasattr(s, "file") else ""),
+            "kind": s.get("kind", "") if isinstance(s, dict) else (s.kind if hasattr(s, "kind") else ""),
+        }
+
+    all_nodes = set(in_deg) | set(out_deg)
+    scored = []
+    for node in all_nodes:
+        i = in_deg[node]
+        o = out_deg[node]
+        if i < 1 or o < 1:
+            continue  # must have both in and out edges
+        bridge_score = i * o
+        sym = sym_lookup.get(node, {})
+        scored.append({
+            "name": node,
+            "file": sym.get("file", ""),
+            "kind": sym.get("kind", ""),
+            "in_degree": i,
+            "out_degree": o,
+            "bridge_score": bridge_score,
+        })
+
+    scored.sort(key=lambda x: x["bridge_score"], reverse=True)
+    return scored[:top_n]

--- a/src/rekipedia/cli/__init__.py
+++ b/src/rekipedia/cli/__init__.py
@@ -8,6 +8,7 @@ from rekipedia.cli.ask import ask_cmd
 from rekipedia.cli.context import context_cmd
 from rekipedia.cli.diff import diff_cmd
 from rekipedia.cli.domain import domain_cmd
+from rekipedia.cli.hotspots import hotspots_cmd
 from rekipedia.cli.embed import embed_cmd
 from rekipedia.cli.export import export_cmd
 from rekipedia.cli.hook import hook_cmd
@@ -53,5 +54,6 @@ main.add_command(note_cmd)
 main.add_command(review_cmd)
 main.add_command(setup_cmd)
 main.add_command(domain_cmd)
+main.add_command(hotspots_cmd)
 main.add_command(tour_cmd)
 main.add_command(onboard_cmd)

--- a/src/rekipedia/cli/hotspots.py
+++ b/src/rekipedia/cli/hotspots.py
@@ -1,0 +1,130 @@
+"""reki hotspots — architectural hotspot detection (hub & bridge nodes)."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import click
+from rich.console import Console
+from rich.table import Table
+
+console = Console()
+
+
+def _truncate(s: str, n: int) -> str:
+    return s if len(s) <= n else s[: n - 1] + "…"
+
+
+def _render_table(hubs: list[dict], bridges: list[dict], top: int) -> None:
+    console.print(f"\n🏗  [bold]Architectural Hotspots[/bold] — top {top}\n")
+
+    # Hub nodes
+    console.print("[bold yellow]HUB NODES[/bold yellow] (most connected)")
+    hub_tbl = Table(show_header=True, header_style="bold", box=None, padding=(0, 2))
+    hub_tbl.add_column("Rank", justify="right", style="dim", width=5)
+    hub_tbl.add_column("Symbol", min_width=30)
+    hub_tbl.add_column("File", min_width=30)
+    hub_tbl.add_column("In", justify="right", width=5)
+    hub_tbl.add_column("Out", justify="right", width=5)
+    hub_tbl.add_column("Total", justify="right", width=6)
+
+    for rank, node in enumerate(hubs, 1):
+        hub_tbl.add_row(
+            str(rank),
+            _truncate(node["name"], 35),
+            _truncate(node.get("file", ""), 35),
+            str(node["in_degree"]),
+            str(node["out_degree"]),
+            str(node["total_degree"]),
+        )
+    console.print(hub_tbl)
+
+    console.print()
+    console.print("[bold yellow]BRIDGE NODES[/bold yellow] (cross-boundary connectors)")
+    bridge_tbl = Table(show_header=True, header_style="bold", box=None, padding=(0, 2))
+    bridge_tbl.add_column("Rank", justify="right", style="dim", width=5)
+    bridge_tbl.add_column("Symbol", min_width=30)
+    bridge_tbl.add_column("File", min_width=30)
+    bridge_tbl.add_column("In×Out", justify="right", width=8)
+
+    for rank, node in enumerate(bridges, 1):
+        bridge_tbl.add_row(
+            str(rank),
+            _truncate(node["name"], 35),
+            _truncate(node.get("file", ""), 35),
+            str(node["bridge_score"]),
+        )
+    console.print(bridge_tbl)
+    console.print()
+
+
+def _render_md(hubs: list[dict], bridges: list[dict], top: int) -> str:
+    lines = [f"# Architectural Hotspots — top {top}", ""]
+    lines += [
+        "## Hub Nodes (most connected)",
+        "",
+        "| Rank | Symbol | File | In | Out | Total |",
+        "|-----:|--------|------|---:|----:|------:|",
+    ]
+    for rank, node in enumerate(hubs, 1):
+        lines.append(
+            f"| {rank} | `{node['name']}` | {node.get('file', '')} "
+            f"| {node['in_degree']} | {node['out_degree']} | {node['total_degree']} |"
+        )
+
+    lines += [
+        "",
+        "## Bridge Nodes (cross-boundary connectors)",
+        "",
+        "| Rank | Symbol | File | In×Out |",
+        "|-----:|--------|------|-------:|",
+    ]
+    for rank, node in enumerate(bridges, 1):
+        lines.append(
+            f"| {rank} | `{node['name']}` | {node.get('file', '')} | {node['bridge_score']} |"
+        )
+
+    lines.append("")
+    return "\n".join(lines)
+
+
+@click.command("hotspots")
+@click.argument("repo", default=".", type=click.Path())
+@click.option("--top", default=10, show_default=True, help="Number of nodes to show")
+@click.option(
+    "--format",
+    "fmt",
+    default="table",
+    show_default=True,
+    type=click.Choice(["table", "json", "md"]),
+    help="Output format",
+)
+def hotspots_cmd(repo: str, top: int, fmt: str) -> None:
+    """Identify architectural hotspots: hub nodes and bridge nodes."""
+    from rekipedia.analysis.graph_analysis import get_bridge_nodes, get_hub_nodes
+    from rekipedia.storage.sqlite_store import SqliteStore
+
+    repo_path = Path(repo).resolve()
+    db_path = repo_path / ".rekipedia" / "store.db"
+    if not db_path.exists():
+        alt = repo_path / ".rekipedia" / "rekipedia.db"
+        if alt.exists():
+            db_path = alt
+    if not db_path.exists():
+        console.print(f"[red]No rekipedia DB at {db_path}. Run `reki scan` first.[/red]")
+        raise click.Abort()
+
+    with SqliteStore(db_path) as store:
+        run_id = store.get_latest_run_id(str(repo_path))
+        if not run_id:
+            console.print("[red]No scan runs found.[/red]")
+            raise click.Abort()
+        hubs = get_hub_nodes(store, run_id, top_n=top)
+        bridges = get_bridge_nodes(store, run_id, top_n=top)
+
+    if fmt == "json":
+        click.echo(json.dumps({"hub_nodes": hubs, "bridge_nodes": bridges}, indent=2))
+    elif fmt == "md":
+        click.echo(_render_md(hubs, bridges, top))
+    else:
+        _render_table(hubs, bridges, top)

--- a/src/rekipedia/cli/scan.py
+++ b/src/rekipedia/cli/scan.py
@@ -53,6 +53,7 @@ def _run_with_refactor(repo: Path, output_dir: Path, verbose: bool) -> None:
 @click.option("--no-llm", is_flag=True, default=False, help="Skip all LLM calls — run static analysis only (zero API calls, ~5-10s). All commands except `reki ask` work without an API key.")
 @click.option("--stdout", "stdout_refactor", is_flag=True, default=False, help="Print REFACTOR.md to stdout after scan (useful for piping to Claude Code).")
 @click.option("--with-refactor", is_flag=True, default=False, help="Auto-generate REFACTOR.md after scan completes.")
+@click.option("--hotspots", "with_hotspots", is_flag=True, default=False, help="Auto-generate ARCHITECTURE.md with hotspot analysis after scan completes.")
 @click.option(
     "--doc-type",
     "doc_type",
@@ -95,6 +96,7 @@ def scan_cmd(
     no_llm: bool,
     stdout_refactor: bool,
     with_refactor: bool,
+    with_hotspots: bool,
     focus: tuple[str, ...],
     doc_type: str,
     workers: int | None,
@@ -270,3 +272,32 @@ def scan_cmd(
         console.rule()
         console.print("[bold cyan]rekipedia refactor[/bold cyan] (triggered by --with-refactor)")
         _run_with_refactor(repo, output_dir, verbose)
+
+    # ── Optional: generate ARCHITECTURE.md with hotspot analysis ──────────────
+    if with_hotspots:
+        console.rule()
+        console.print("[bold cyan]rekipedia hotspots[/bold cyan] (triggered by --hotspots)")
+        try:
+            from rekipedia.analysis.graph_analysis import get_bridge_nodes, get_hub_nodes
+            from rekipedia.cli.hotspots import _render_md
+            from rekipedia.storage.sqlite_store import SqliteStore
+
+            db_path = output_dir / "store.db"
+            with SqliteStore(db_path) as store:
+                run_id = store.get_latest_run_id(str(repo))
+                if run_id:
+                    hubs = get_hub_nodes(store, run_id, top_n=20)
+                    bridges = get_bridge_nodes(store, run_id, top_n=20)
+                    md = _render_md(hubs, bridges, 20)
+                    wiki_dir = output_dir / "wiki"
+                    wiki_dir.mkdir(parents=True, exist_ok=True)
+                    arch_path = wiki_dir / "ARCHITECTURE.md"
+                    arch_path.write_text(md, encoding="utf-8")
+                    console.print(f"  ARCHITECTURE.md : {arch_path}")
+                else:
+                    console.print("[yellow]  No scan runs found — skipping hotspots.[/yellow]")
+        except Exception as exc:
+            if verbose:
+                console.print_exception(show_locals=True)
+            else:
+                console.print(f"[yellow]  --hotspots failed: {exc}[/yellow]")

--- a/tests/test_hotspots.py
+++ b/tests/test_hotspots.py
@@ -1,0 +1,251 @@
+"""Tests for reki hotspots — hub & bridge node detection."""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers — build an in-memory-like SqliteStore with mock data
+# ---------------------------------------------------------------------------
+
+def _make_store_with_data():
+    """Create a temporary SqliteStore with mock symbols and relationships."""
+    from rekipedia.storage.sqlite_store import SqliteStore
+
+    tmp = tempfile.mkdtemp()
+    db_path = Path(tmp) / "store.db"
+    store = SqliteStore(db_path)
+    store.open()
+
+    run_id = "test-run-001"
+    store.upsert_run(run_id, tmp)
+
+    # Upsert symbols
+    symbols = [
+        {"name": "Scanner.scan", "kind": "method", "file": "scanner.py", "line": 10, "docstring": ""},
+        {"name": "SqliteStore.__init__", "kind": "method", "file": "storage/sqlite_store.py", "line": 20, "docstring": ""},
+        {"name": "run_ask", "kind": "function", "file": "orchestrator/run_ask.py", "line": 5, "docstring": ""},
+        {"name": "parse_args", "kind": "function", "file": "cli/main.py", "line": 1, "docstring": ""},
+        {"name": "leaf_func", "kind": "function", "file": "utils.py", "line": 1, "docstring": ""},
+    ]
+    store.upsert_symbols(run_id, symbols)
+
+    # Build relationships:
+    # Scanner.scan: in=3 (called by A, B, C), out=5 (calls D,E,F,G,H) → total=8, bridge=15
+    # run_ask: in=4, out=4 → total=8, bridge=16 (top bridge)
+    # SqliteStore.__init__: in=5, out=2 → total=7
+    # parse_args: in=1, out=3 → total=4
+    # leaf_func: in=6, out=0 → total=6
+    rels = []
+    # Scanner.scan gets called by 3 sources
+    for i in range(3):
+        rels.append({"from_": f"caller_{i}", "to": "Scanner.scan", "kind": "calls", "file": "x.py", "confidence": 1.0, "evidence_tag": ""})
+    # Scanner.scan calls 5 things
+    for i in range(5):
+        rels.append({"from_": "Scanner.scan", "to": f"callee_{i}", "kind": "calls", "file": "scanner.py", "confidence": 1.0, "evidence_tag": ""})
+
+    # run_ask: in=4, out=4
+    for i in range(4):
+        rels.append({"from_": f"src_{i}", "to": "run_ask", "kind": "calls", "file": "x.py", "confidence": 1.0, "evidence_tag": ""})
+    for i in range(4):
+        rels.append({"from_": "run_ask", "to": f"tgt_{i}", "kind": "calls", "file": "x.py", "confidence": 1.0, "evidence_tag": ""})
+
+    # SqliteStore.__init__: in=5, out=2
+    for i in range(5):
+        rels.append({"from_": f"init_caller_{i}", "to": "SqliteStore.__init__", "kind": "calls", "file": "x.py", "confidence": 1.0, "evidence_tag": ""})
+    for i in range(2):
+        rels.append({"from_": "SqliteStore.__init__", "to": f"init_dep_{i}", "kind": "calls", "file": "x.py", "confidence": 1.0, "evidence_tag": ""})
+
+    # parse_args: in=1, out=3
+    rels.append({"from_": "main", "to": "parse_args", "kind": "calls", "file": "x.py", "confidence": 1.0, "evidence_tag": ""})
+    for i in range(3):
+        rels.append({"from_": "parse_args", "to": f"opt_{i}", "kind": "calls", "file": "x.py", "confidence": 1.0, "evidence_tag": ""})
+
+    # leaf_func: in=6, out=0
+    for i in range(6):
+        rels.append({"from_": f"leaf_caller_{i}", "to": "leaf_func", "kind": "calls", "file": "x.py", "confidence": 1.0, "evidence_tag": ""})
+
+    store.upsert_relationships(run_id, rels)
+    return store, run_id, db_path
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+class TestGetHubNodes:
+    def test_returns_top_n_by_degree(self):
+        from rekipedia.analysis.graph_analysis import get_hub_nodes
+
+        store, run_id, _ = _make_store_with_data()
+        try:
+            hubs = get_hub_nodes(store, run_id, top_n=3)
+            assert len(hubs) == 3
+            # top nodes should be sorted descending by total_degree
+            degrees = [h["total_degree"] for h in hubs]
+            assert degrees == sorted(degrees, reverse=True)
+        finally:
+            store.close()
+
+    def test_contains_required_fields(self):
+        from rekipedia.analysis.graph_analysis import get_hub_nodes
+
+        store, run_id, _ = _make_store_with_data()
+        try:
+            hubs = get_hub_nodes(store, run_id, top_n=5)
+            for h in hubs:
+                assert "name" in h
+                assert "in_degree" in h
+                assert "out_degree" in h
+                assert "total_degree" in h
+                assert h["total_degree"] == h["in_degree"] + h["out_degree"]
+        finally:
+            store.close()
+
+    def test_top_n_respected(self):
+        from rekipedia.analysis.graph_analysis import get_hub_nodes
+
+        store, run_id, _ = _make_store_with_data()
+        try:
+            hubs = get_hub_nodes(store, run_id, top_n=2)
+            assert len(hubs) <= 2
+        finally:
+            store.close()
+
+    def test_empty_store_returns_empty(self):
+        from rekipedia.analysis.graph_analysis import get_hub_nodes
+        from rekipedia.storage.sqlite_store import SqliteStore
+
+        tmp = tempfile.mkdtemp()
+        db_path = Path(tmp) / "empty.db"
+        with SqliteStore(db_path) as store:
+            store.upsert_run("run-empty", tmp)
+            hubs = get_hub_nodes(store, "run-empty", top_n=10)
+        assert hubs == []
+
+
+class TestGetBridgeNodes:
+    def test_returns_top_n_by_bridge_score(self):
+        from rekipedia.analysis.graph_analysis import get_bridge_nodes
+
+        store, run_id, _ = _make_store_with_data()
+        try:
+            bridges = get_bridge_nodes(store, run_id, top_n=3)
+            scores = [b["bridge_score"] for b in bridges]
+            assert scores == sorted(scores, reverse=True)
+        finally:
+            store.close()
+
+    def test_bridge_score_is_in_times_out(self):
+        from rekipedia.analysis.graph_analysis import get_bridge_nodes
+
+        store, run_id, _ = _make_store_with_data()
+        try:
+            bridges = get_bridge_nodes(store, run_id, top_n=10)
+            for b in bridges:
+                assert b["bridge_score"] == b["in_degree"] * b["out_degree"]
+                assert b["in_degree"] >= 1
+                assert b["out_degree"] >= 1
+        finally:
+            store.close()
+
+    def test_leaf_nodes_excluded(self):
+        """Nodes with only in_degree or only out_degree should not appear."""
+        from rekipedia.analysis.graph_analysis import get_bridge_nodes
+
+        store, run_id, _ = _make_store_with_data()
+        try:
+            bridges = get_bridge_nodes(store, run_id, top_n=20)
+            names = {b["name"] for b in bridges}
+            # leaf_func has out_degree=0 so should not be a bridge
+            assert "leaf_func" not in names
+        finally:
+            store.close()
+
+    def test_contains_required_fields(self):
+        from rekipedia.analysis.graph_analysis import get_bridge_nodes
+
+        store, run_id, _ = _make_store_with_data()
+        try:
+            bridges = get_bridge_nodes(store, run_id, top_n=5)
+            for b in bridges:
+                assert "name" in b
+                assert "in_degree" in b
+                assert "out_degree" in b
+                assert "bridge_score" in b
+        finally:
+            store.close()
+
+
+class TestHotspotsCli:
+    def test_table_output_runs_without_error(self, tmp_path):
+        from click.testing import CliRunner
+
+        from rekipedia.cli.hotspots import hotspots_cmd
+        from rekipedia.storage.sqlite_store import SqliteStore
+
+        # Create a minimal store
+        db_dir = tmp_path / ".rekipedia"
+        db_dir.mkdir()
+        db_path = db_dir / "store.db"
+        with SqliteStore(db_path) as store:
+            run_id = "r1"
+            store.upsert_run(run_id, str(tmp_path), status="success")
+            store.upsert_symbols(run_id, [{"name": "foo", "kind": "function", "file": "a.py", "line": 1, "docstring": ""}])
+            store.upsert_relationships(run_id, [
+                {"from_": "bar", "to": "foo", "kind": "calls", "file": "b.py", "confidence": 1.0, "evidence_tag": ""},
+                {"from_": "foo", "to": "baz", "kind": "calls", "file": "a.py", "confidence": 1.0, "evidence_tag": ""},
+            ])
+
+        runner = CliRunner()
+        result = runner.invoke(hotspots_cmd, [str(tmp_path), "--top", "5", "--format", "table"])
+        assert result.exit_code == 0, result.output
+
+    def test_json_output_is_valid_json(self, tmp_path):
+        from click.testing import CliRunner
+
+        from rekipedia.cli.hotspots import hotspots_cmd
+        from rekipedia.storage.sqlite_store import SqliteStore
+
+        db_dir = tmp_path / ".rekipedia"
+        db_dir.mkdir()
+        db_path = db_dir / "store.db"
+        with SqliteStore(db_path) as store:
+            run_id = "r2"
+            store.upsert_run(run_id, str(tmp_path), status="success")
+            store.upsert_symbols(run_id, [{"name": "alpha", "kind": "function", "file": "a.py", "line": 1, "docstring": ""}])
+            store.upsert_relationships(run_id, [
+                {"from_": "x", "to": "alpha", "kind": "calls", "file": "x.py", "confidence": 1.0, "evidence_tag": ""},
+                {"from_": "alpha", "to": "y", "kind": "calls", "file": "a.py", "confidence": 1.0, "evidence_tag": ""},
+            ])
+
+        runner = CliRunner()
+        result = runner.invoke(hotspots_cmd, [str(tmp_path), "--format", "json"])
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert "hub_nodes" in data
+        assert "bridge_nodes" in data
+
+    def test_md_output_contains_headers(self, tmp_path):
+        from click.testing import CliRunner
+
+        from rekipedia.cli.hotspots import hotspots_cmd
+        from rekipedia.storage.sqlite_store import SqliteStore
+
+        db_dir = tmp_path / ".rekipedia"
+        db_dir.mkdir()
+        db_path = db_dir / "store.db"
+        with SqliteStore(db_path) as store:
+            run_id = "r3"
+            store.upsert_run(run_id, str(tmp_path), status="success")
+
+        runner = CliRunner()
+        result = runner.invoke(hotspots_cmd, [str(tmp_path), "--format", "md"])
+        assert result.exit_code == 0
+        assert "# Architectural Hotspots" in result.output
+        assert "Hub Nodes" in result.output
+        assert "Bridge Nodes" in result.output


### PR DESCRIPTION
Implements #165.

Adds reki hotspots command for architectural hotspot detection.

### Changes
- analysis/graph_analysis.py: get_hub_nodes() and get_bridge_nodes()
- cli/hotspots.py: new reki hotspots command with --top N and --format table|json|md
- cli/scan.py: --hotspots flag to auto-generate ARCHITECTURE.md
- 11 tests passing
- Version bumped to 0.17.21

Closes #165